### PR TITLE
Fix problem with sequential make causes by parallel make change.  The…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ sonLib:
 	cd submodules/sonLib && PKG_CONFIG_PATH=${CWD}/lib/pkgconfig:${PKG_CONFIG_PATH} ${MAKE}
 	mkdir -p ${BINDIR} ${LIBDIR} ${INCLDIR}
 	rm -rf submodules/sonLib/bin/*.dSYM
-	ln -f submodules/sonLib/lib/*.a ${LIBDIR}
+	ln -f submodules/sonLib/lib/sonLib.a ${LIBDIR}/sonLib.a
+	ln -f submodules/sonLib/lib/cuTest.a ${LIBDIR}/cuTest.a
 	ln -f submodules/sonLib/lib/sonLib.a ${LIBDIR}/libsonLib.a
 
 stPafDependencies = ${sonLibDir}/sonLib.a ${sonLibDir}/cuTest.a
@@ -26,13 +27,13 @@ ${sonLibDir}/sonLib.a : sonLib
 
 ${sonLibDir}/cuTest.a : sonLib
 
-${LIBDIR}/stPaf.a : ${libSources} ${libHeaders}  ${stPafDependencies} | sonlib
+${LIBDIR}/stPaf.a : ${libSources} ${libHeaders}  ${stPafDependencies}
 	${CC} ${CPPFLAGS} ${CFLAGS} ${LDFLAGS} -c ${libSources}
 	${AR} rc stPaf.a *.o
 	${RANLIB} stPaf.a
 	mv stPaf.a ${LIBDIR}/
 
-${BINDIR}/paffy : paffy_main.c ${LIBDEPENDS} ${commonPafLibs} ${libSources} ${libHeaders}
+${BINDIR}/paffy : paffy_main.c ${LIBDEPENDS} ${stPafDependencies} ${commonPafLibs} ${libHeaders}
 	${CC} ${CPPFLAGS} ${CFLAGS} -o ${BINDIR}/paffy paffy_main.c ${libSources} ${commonPafLibs} ${LDLIBS}
 
 ${BINDIR}/stPafTests : ${libTests} ${LIBDIR}/stPaf.a ${stPafDependencies}


### PR DESCRIPTION
… link of the paffy program was used .o files that were purged rather then the lib that was built.