### PR TITLE
Smaller PAF

### DIFF
--- a/impl/chaining.c
+++ b/impl/chaining.c
@@ -268,7 +268,7 @@ stList *paf_chain(stList *pafs, int64_t (*gap_cost)(int64_t, int64_t, void *), v
     // Split into forward and reverse strand alignments
     stList *positive_strand_pafs = stList_construct();
     stList *negative_strand_pafs = stList_construct();
-    stHash *pafs_to_trims = stHash_construct2(NULL, (void (*)(void *))stIntTuple_destruct);
+    stHash *pafs_to_trims = stHash_construct();
     for(int64_t i=0; i<stList_length(pafs); i++) {
         Paf *p = stList_get(pafs, i);
         assert(percentage_to_trim >= 0 && percentage_to_trim <= 1.0);
@@ -286,7 +286,7 @@ stList *paf_chain(stList *pafs, int64_t (*gap_cost)(int64_t, int64_t, void *), v
         p->target_end -= trim;
 
         // Track how much was trimmed
-        stHash_insert(pafs_to_trims, p, stIntTuple_construct1(trim));
+        stHash_insert(pafs_to_trims, p, (void*)trim);
 
         if(p->same_strand) {
             stList_append(positive_strand_pafs, p);
@@ -319,7 +319,7 @@ stList *paf_chain(stList *pafs, int64_t (*gap_cost)(int64_t, int64_t, void *), v
         Paf *p = stList_get(positive_chained_pafs, i);
 
         assert(stHash_search(pafs_to_trims, p) != NULL);
-        int64_t trim = stIntTuple_get(stHash_search(pafs_to_trims, p), 0);
+        int64_t trim = (int64_t)stHash_search(pafs_to_trims, p);
 
         p->query_start -= trim;
         p->query_end += trim;

--- a/impl/chaining.c
+++ b/impl/chaining.c
@@ -268,7 +268,7 @@ stList *paf_chain(stList *pafs, int64_t (*gap_cost)(int64_t, int64_t, void *), v
     // Split into forward and reverse strand alignments
     stList *positive_strand_pafs = stList_construct();
     stList *negative_strand_pafs = stList_construct();
-    stHash *pafs_to_trims = stHash_construct();
+    stHash *pafs_to_trims = stHash_construct2(NULL, (void (*)(void *))stIntTuple_destruct);
     for(int64_t i=0; i<stList_length(pafs); i++) {
         Paf *p = stList_get(pafs, i);
         assert(percentage_to_trim >= 0 && percentage_to_trim <= 1.0);
@@ -286,7 +286,7 @@ stList *paf_chain(stList *pafs, int64_t (*gap_cost)(int64_t, int64_t, void *), v
         p->target_end -= trim;
 
         // Track how much was trimmed
-        stHash_insert(pafs_to_trims, p, (void*)trim);
+        stHash_insert(pafs_to_trims, p, stIntTuple_construct1(trim));
 
         if(p->same_strand) {
             stList_append(positive_strand_pafs, p);
@@ -319,7 +319,7 @@ stList *paf_chain(stList *pafs, int64_t (*gap_cost)(int64_t, int64_t, void *), v
         Paf *p = stList_get(positive_chained_pafs, i);
 
         assert(stHash_search(pafs_to_trims, p) != NULL);
-        int64_t trim = (int64_t)stHash_search(pafs_to_trims, p);
+        int64_t trim = stIntTuple_get(stHash_search(pafs_to_trims, p), 0);
 
         p->query_start -= trim;
         p->query_end += trim;

--- a/inc/paf.h
+++ b/inc/paf.h
@@ -59,9 +59,9 @@ typedef enum _cigarOp {
 
 typedef struct _cigar Cigar;
 struct _cigar {
-    CigarOp op;
-    int64_t length;
     Cigar *next;
+    int64_t length : 56;
+    int64_t op : 8;
 };
 
 typedef struct _paf {
@@ -73,7 +73,6 @@ typedef struct _paf {
     int64_t target_length;
     int64_t target_start; // Zero-based
     int64_t target_end; // Zero-based
-    bool same_strand; // If 0 then query substring is reverse complement with respect to the target
     Cigar *cigar; // Ordered by the target sequence
     int64_t score; // the dp alignment score
     int64_t mapping_quality;
@@ -83,6 +82,7 @@ typedef struct _paf {
     // chaining (somewhat like the nesting of chains within nets in ucsc chains and nets).
     int64_t chain_id; // a tag to indicate which chain a paf belongs to
     int64_t chain_score; // a tag to indicate the score the of chain the paf belongs to, uses s1 tag
+    bool same_strand; // If 0 then query substring is reverse complement with respect to the target    
     char type; // is 'P' primary / 'S' secondary / 'I' inversion
 } Paf;
 


### PR DESCRIPTION
This squishes cigars a bit, reducing `sizeof(Cigar)` from 24 to 16.  It *should* have a big impact on `paffy chains` memory, but in practice only seems to have a small one.

By aligning memory better in the Paf struct, it should also save 8bytes / paf line.  