### PR TITLE
fix compiler warning

### DIFF
--- a/impl/paf.c
+++ b/impl/paf.c
@@ -246,7 +246,7 @@ char *paf_print(Paf *paf) {
                     op_char = 'X';
                     break;
             }
-            i += sprintf(buffer+i, "%" PRIi64 "%c", c->length, op_char);
+            i += sprintf(buffer+i, "%" PRIi64 "%c", (int64_t)c->length, op_char);
             c = c->next;
             if(i > buf_size) {
                 st_errAbort("Size of paf record exceeded buffer size (2)\n");


### PR DESCRIPTION
Oops, need to cast away that byte I stole from length to make the compiler happy (the warning breaks cactus's CI tests). 