### PR TITLE
Respect `CACTUS_LEGACY_ARCH` for Cactus build

### DIFF
--- a/include.mk
+++ b/include.mk
@@ -65,6 +65,7 @@ else
 		export avx2 = 1
 #		flags to include simde abpoa in cactus on X86
 		CFLAGS+= -mavx2
+	endif
 endif
 # flags needed to include simde abpoa in cactus on any architecture
 ifdef CACTUS_LEGACY_ARCH

--- a/include.mk
+++ b/include.mk
@@ -57,11 +57,21 @@ export aarch64 = 1
 # flags to include simde abpoa in cactus on ARM
 CFLAGS+= -march=armv8-a+simd
 else
-# flags to build abpoa
-export avx2 = 1
+	ifdef CACTUS_LEGACY_ARCH
+		export sse2 = 1
+		CFLAGS+= -msse2
+	else
+#		flags to build abpoa
+		export avx2 = 1
+#		flags to include simde abpoa in cactus on X86
+		CFLAGS+= -mavx2
 endif
 # flags needed to include simde abpoa in cactus on any architecture
-CFLAGS+= -D__AVX2__ -DUSE_SIMDE -DSIMDE_ENABLE_NATIVE_ALIASES
+ifdef CACTUS_LEGACY_ARCH
+	CFLAGS+= -D__SSE2__ -DUSE_SIMDE -DSIMDE_ENABLE_NATIVE_ALIASES
+else
+	CFLAGS+= -D__AVX2__ -DUSE_SIMDE -DSIMDE_ENABLE_NATIVE_ALIASES
+endif
 
 inclDirs = inc submodules/sonLib/C/inc submodules/sonLib/externalTools/cutest
 


### PR DESCRIPTION
If `CACTUS_LEGACY_ARCH` is set, use SSE2 and not AVX2.