### PR TITLE
use sonlib (which breaks lines) to write fastas

### DIFF
--- a/impl/fasta_chunk.c
+++ b/impl/fasta_chunk.c
@@ -76,8 +76,9 @@ static void processSequenceToChunk(void* dest, const char *fastaHeader, const ch
         // be ready to print more sequence
         startChunkingSequences();
 
-        // print the header to the file
-        fprintf(chunkFileHandle, ">%s|%" PRIi64 "|%" PRIi64 "\n", fastaHeader, sequenceLength, i);
+        // print the header to a buffer
+        char *header = st_calloc(strlen(fastaHeader) + 2048, sizeof(char));
+        sprintf(header, "%s|%" PRIi64 "|%" PRIi64, fastaHeader, sequenceLength, i);
 
         // Get end of chunk, including the extra overlap
         int64_t j = (i + chunkSize + chunkOverlapSize) <= sequenceLength ? (i + chunkSize + chunkOverlapSize) : sequenceLength;
@@ -93,8 +94,9 @@ static void processSequenceToChunk(void* dest, const char *fastaHeader, const ch
         }
 
         // print the sequence to the file
-        fprintf(chunkFileHandle, "%s\n", seq_chunk);
+        fastaWrite(seq_chunk, header, chunkFileHandle);
         free(seq_chunk); // cleanup the fragment
+        free(header);
 
         // update the remaining chunk
         updateChunkRemaining(j - i);

--- a/impl/fasta_extract.c
+++ b/impl/fasta_extract.c
@@ -43,8 +43,11 @@ static void report_interval(FILE *output, char *seq_name, int64_t start, int64_t
         char c = tolower(s[i]);
         assert(c == 'a' || c == 'c' || c == 'g' || c == 't' || c == 'n');
     }
-    fprintf(output, ">%s|%" PRIi64 "|%" PRIi64 "\n%s\n", seq_name, seq_length, start, s);
+    char *header = st_calloc(strlen(seq_name) + 2048, sizeof(char));
+    sprintf(header, "%s|%" PRIi64 "|%" PRIi64, seq_name, seq_length, start);
+    fastaWrite(s, header, output);
     free(s);
+    free(header);
 }
 
 typedef struct _interval {


### PR DESCRIPTION
This replaces `fprintf` with `fastaWrite` in `faffy chunk` and `faffy extract` in order to avoid writing super long lines to text files, which can cause trouble like https://github.com/ComparativeGenomicsToolkit/cactus/issues/1670

I didn't do `faffy merge` because it seemed more complicated, and because I don't think it's used in cactus (only found in disabled-by-default preprocessor chunking logic)