### PR TITLE
Add paffy split_file subcommand

### DIFF
--- a/impl/paf_add_mismatches.c
+++ b/impl/paf_add_mismatches.c
@@ -104,7 +104,9 @@ int paffy_add_mismatches_main(int argc, char *argv[]) {
     FILE *output = outputFile == NULL ? stdout : fopen(outputFile, "w");
 
     Paf *paf;
-    while((paf = paf_read(input, 1)) != NULL) {
+    int64_t paf_buffer_length = 100;
+    char *paf_buffer = st_malloc(sizeof(char) * paf_buffer_length);
+    while((paf = paf_read_with_buffer(input, 1, &paf_buffer, &paf_buffer_length)) != NULL) {
 
         if(remove_mismatches) { // Remove match/mismatch encoding to replace with maximal gapless alignments
             paf_remove_mismatches(paf);
@@ -131,11 +133,12 @@ int paffy_add_mismatches_main(int argc, char *argv[]) {
         paf_check(paf);
 
         // Now print the alignment
-        paf_write(paf, output);
+        paf_write_with_buffer(paf, output, &paf_buffer, &paf_buffer_length);
 
         // Cleanup
         paf_destruct(paf);
     }
+    free(paf_buffer);
 
     //////////////////////////////////////////////
     // Cleanup

--- a/impl/paf_dechunk.c
+++ b/impl/paf_dechunk.c
@@ -109,12 +109,15 @@ int paffy_dechunk_main(int argc, char *argv[]) {
      FILE *output = outputFile == NULL ? stdout : fopen(outputFile, "w");
 
      Paf *paf;
-     while((paf = paf_read(input, 1)) != NULL) {
+     int64_t paf_buffer_length = 100;
+     char *paf_buffer = st_malloc(sizeof(char) * paf_buffer_length);
+     while((paf = paf_read_with_buffer(input, 1, &paf_buffer, &paf_buffer_length)) != NULL) {
          paf_dechunk(paf, fix_query, fix_target);
          paf_check(paf);
-         paf_write(paf, output);
+         paf_write_with_buffer(paf, output, &paf_buffer, &paf_buffer_length);
          paf_destruct(paf);
      }
+     free(paf_buffer);
 
      //////////////////////////////////////////////
      // Cleanup

--- a/impl/paf_dedupe.c
+++ b/impl/paf_dedupe.c
@@ -112,7 +112,9 @@ int paffy_dedupe_main(int argc, char *argv[]) {
     FILE *output = outputFile == NULL ? stdout : fopen(outputFile, "w");
     stHash *pafs = stHash_construct3(paf_hash_key, paf_equal_key, NULL, (void (*)(void *))paf_destruct);
     Paf *paf;
-    while((paf = paf_read(input, 0)) != NULL) {
+    int64_t paf_buffer_length = 100;
+    char *paf_buffer = st_malloc(sizeof(char) * paf_buffer_length);
+    while((paf = paf_read_with_buffer(input, 0, &paf_buffer, &paf_buffer_length)) != NULL) {
         // Get the query sequence
         Paf *pPaf = stHash_search(pafs, paf);
         if(check_inverse && pPaf == NULL) { // In case we want to check if we already output the inverse
@@ -123,7 +125,7 @@ int paffy_dedupe_main(int argc, char *argv[]) {
         }
         if(pPaf == NULL) {  // If duplicate is not already in there
             stHash_insert(pafs, paf, paf);  // Add the paf
-            paf_write(paf, output); // Write the paf to the output
+            paf_write_with_buffer(paf, output, &paf_buffer, &paf_buffer_length); // Write the paf to the output
         }
         else {
             // If debug output report info on dupe
@@ -143,6 +145,8 @@ int paffy_dedupe_main(int argc, char *argv[]) {
     //////////////////////////////////////////////
     // Cleanup
     //////////////////////////////////////////////
+
+    free(paf_buffer);
 
     if(inputFile != NULL) {
         fclose(input);

--- a/impl/paf_filter.c
+++ b/impl/paf_filter.c
@@ -118,7 +118,9 @@ static void usage(void) {
      FILE *output = outputFile == NULL ? stdout : fopen(outputFile, "w");
 
      Paf *paf;
-     while((paf = paf_read(input, 1)) != NULL) {
+     int64_t paf_buffer_length = 100;
+     char *paf_buffer = st_malloc(sizeof(char) * paf_buffer_length);
+     while((paf = paf_read_with_buffer(input, 1, &paf_buffer, &paf_buffer_length)) != NULL) {
          // Calculate identity stats
          int64_t matches=0, mismatches=0, query_inserts=0, query_deletes=0,
                  query_insert_bases=0, query_delete_bases=0;
@@ -133,25 +135,26 @@ static void usage(void) {
                  if(st_getLogLevel() == debug) {
                      st_logDebug("Filtering alignment with matches:%" PRIi64 ", identity: %f (%f with gaps), score: %" PRIi64
                      ", chain-score:%" PRIi64 "\n", matches, identity, identity_with_gaps, paf->score, paf->chain_score);
-                     paf_write(paf, stderr);
+                     paf_write_with_buffer(paf, stderr, &paf_buffer, &paf_buffer_length);
                  }
              }
              else {
-                 paf_write(paf, output);
+                 paf_write_with_buffer(paf, output, &paf_buffer, &paf_buffer_length);
              }
          }
          else {
              if(invert) {
-                 paf_write(paf, output);
+                 paf_write_with_buffer(paf, output, &paf_buffer, &paf_buffer_length);
              }
              else if(st_getLogLevel() == debug) {
                 st_logDebug("Filtering alignment with matches:%" PRIi64 ", identity: %f (%f with gaps), score: %" PRIi64
                  ", chain-score:%" PRIi64 "\n", matches, identity, identity_with_gaps, paf->score, paf->chain_score);
-                paf_write(paf, stderr);
+                paf_write_with_buffer(paf, stderr, &paf_buffer, &paf_buffer_length);
             }
          }
          paf_destruct(paf);
      }
+     free(paf_buffer);
 
      //////////////////////////////////////////////
      // Cleanup

--- a/impl/paf_invert.c
+++ b/impl/paf_invert.c
@@ -79,10 +79,12 @@ static void usage(void) {
      FILE *output = outputFile == NULL ? stdout : fopen(outputFile, "w");
 
      Paf *paf;
-     while((paf = paf_read(input, 1)) != NULL) {
+     int64_t paf_buffer_length = 100;
+     char *paf_buffer = st_malloc(sizeof(char) * paf_buffer_length);
+     while((paf = paf_read_with_buffer(input, 1, &paf_buffer, &paf_buffer_length)) != NULL) {
          paf_invert(paf); // the invert routine
          paf_check(paf);
-         paf_write(paf, output);
+         paf_write_with_buffer(paf, output, &paf_buffer, &paf_buffer_length);
          paf_destruct(paf);
      }
 
@@ -90,6 +92,7 @@ static void usage(void) {
      // Cleanup
      //////////////////////////////////////////////
 
+     free(paf_buffer);
      if(inputFile != NULL) {
          fclose(input);
      }

--- a/impl/paf_shatter.c
+++ b/impl/paf_shatter.c
@@ -83,14 +83,17 @@ int paffy_shatter_main(int argc, char *argv[]) {
     FILE *output = outputFile == NULL ? stdout : fopen(outputFile, "w");
 
     Paf *paf;
-    while((paf = paf_read(input, 1)) != NULL) {
+    int64_t paf_buffer_length = 100;
+    char *paf_buffer = st_malloc(sizeof(char) * paf_buffer_length);
+    while((paf = paf_read_with_buffer(input, 1, &paf_buffer, &paf_buffer_length)) != NULL) {
         stList *matches = paf_shatter(paf);
         for(int64_t i=0; i<stList_length(matches); i++) {
-            paf_write(stList_get(matches, i), output);
+            paf_write_with_buffer(stList_get(matches, i), output, &paf_buffer, &paf_buffer_length);
         }
         stList_destruct(matches);
         paf_destruct(paf);
     }
+    free(paf_buffer);
 
     //////////////////////////////////////////////
     // Cleanup

--- a/impl/paf_split_file.c
+++ b/impl/paf_split_file.c
@@ -1,0 +1,172 @@
+/*
+ * paffy split_file: Split PAF file into per-target-contig output files
+ *
+ * Released under the MIT license, see LICENSE.txt
+ */
+
+#include "paf.h"
+#include <getopt.h>
+#include <time.h>
+
+static void usage(void) {
+     fprintf(stderr, "paffy split_file [options], version 0.1\n");
+     fprintf(stderr, "Split PAF file into separate output files by target contig name\n");
+     fprintf(stderr, "-i --inputFile : Input paf file. If not specified reads from stdin\n");
+     fprintf(stderr, "-p --prefix : Output file prefix (may include directory path). Default: split_\n");
+     fprintf(stderr, "-m --minTargetLength : Contigs with target_length < m go to <prefix>small.paf. Default: 0 (disabled)\n");
+     fprintf(stderr, "-l --logLevel : Set the log level\n");
+     fprintf(stderr, "-h --help : Print this help message\n");
+ }
+
+/*
+ * Sanitize a target name for use in a filename by replacing '/' with '_'
+ */
+static char *sanitize_filename(const char *name) {
+    char *sanitized = stString_copy(name);
+    for (int64_t i = 0; sanitized[i] != '\0'; i++) {
+        if (sanitized[i] == '/') {
+            sanitized[i] = '_';
+        }
+    }
+    return sanitized;
+}
+
+/*
+ * Get or create an output file handle for the given target name
+ */
+static FILE *get_output_file(stHash *target_to_file, const char *target_name, const char *prefix) {
+    FILE *fh = stHash_search(target_to_file, (void *)target_name);
+    if (fh == NULL) {
+        char *sanitized = sanitize_filename(target_name);
+        char *filename = stString_print("%s%s.paf", prefix, sanitized);
+        fh = fopen(filename, "w");
+        if (fh == NULL) {
+            st_errAbort("Could not open output file: %s\n", filename);
+        }
+        st_logInfo("Opened output file: %s\n", filename);
+        stHash_insert(target_to_file, stString_copy(target_name), fh);
+        free(sanitized);
+        free(filename);
+    }
+    return fh;
+}
+
+ int paffy_split_file_main(int argc, char *argv[]) {
+     time_t startTime = time(NULL);
+
+     /*
+      * Arguments/options
+      */
+     char *logLevelString = NULL;
+     char *inputFile = NULL;
+     char *prefix = "split_";
+     int64_t minTargetLength = 0;
+
+     ///////////////////////////////////////////////////////////////////////////
+     // Parse the inputs
+     ///////////////////////////////////////////////////////////////////////////
+
+     while (1) {
+         static struct option long_options[] = { { "logLevel", required_argument, 0, 'l' },
+                                                 { "inputFile", required_argument, 0, 'i' },
+                                                 { "prefix", required_argument, 0, 'p' },
+                                                 { "minTargetLength", required_argument, 0, 'm' },
+                                                 { "help", no_argument, 0, 'h' },
+                                                 { 0, 0, 0, 0 } };
+
+         int option_index = 0;
+         int64_t key = getopt_long(argc, argv, "l:i:p:m:h", long_options, &option_index);
+         if (key == -1) {
+             break;
+         }
+
+         switch (key) {
+             case 'l':
+                 logLevelString = optarg;
+                 break;
+             case 'i':
+                 inputFile = optarg;
+                 break;
+             case 'p':
+                 prefix = optarg;
+                 break;
+             case 'm':
+                 minTargetLength = atol(optarg);
+                 break;
+             case 'h':
+                 usage();
+                 return 0;
+             default:
+                 usage();
+                 return 1;
+         }
+     }
+
+     //////////////////////////////////////////////
+     //Log the inputs
+     //////////////////////////////////////////////
+
+     st_setLogLevelFromString(logLevelString);
+     st_logInfo("Input file string : %s\n", inputFile);
+     st_logInfo("Output prefix : %s\n", prefix);
+     st_logInfo("Min target length : %" PRIi64 "\n", minTargetLength);
+
+     //////////////////////////////////////////////
+     // Split the paf file
+     //////////////////////////////////////////////
+
+     FILE *input = inputFile == NULL ? stdin : fopen(inputFile, "r");
+     stHash *target_to_file = stHash_construct3(stHash_stringKey, stHash_stringEqualKey, free, NULL);
+     FILE *small_file = NULL;
+
+     Paf *paf;
+     int64_t total_records = 0;
+     while((paf = paf_read(input, 0)) != NULL) {
+         FILE *output;
+         if (minTargetLength > 0 && paf->target_length < minTargetLength) {
+             // Lazily open the small contigs file
+             if (small_file == NULL) {
+                 char *filename = stString_print("%ssmall.paf", prefix);
+                 small_file = fopen(filename, "w");
+                 if (small_file == NULL) {
+                     st_errAbort("Could not open output file: %s\n", filename);
+                 }
+                 st_logInfo("Opened small contigs output file: %s\n", filename);
+                 free(filename);
+             }
+             output = small_file;
+         } else {
+             output = get_output_file(target_to_file, paf->target_name, prefix);
+         }
+         paf_write(paf, output);
+         total_records++;
+         paf_destruct(paf);
+     }
+
+     //////////////////////////////////////////////
+     // Cleanup
+     //////////////////////////////////////////////
+
+     if(inputFile != NULL) {
+         fclose(input);
+     }
+
+     // Close all per-target output files
+     stHashIterator *it = stHash_getIterator(target_to_file);
+     char *key;
+     while ((key = stHash_getNext(it)) != NULL) {
+         FILE *fh = stHash_search(target_to_file, key);
+         fclose(fh);
+     }
+     stHash_destructIterator(it);
+     stHash_destruct(target_to_file);
+
+     if (small_file != NULL) {
+         fclose(small_file);
+     }
+
+     st_logInfo("Paffy split_file is done! Split %" PRIi64 " records, %" PRIi64 " seconds have elapsed\n",
+                total_records, time(NULL) - startTime);
+
+     return 0;
+ }

--- a/impl/paf_split_file.c
+++ b/impl/paf_split_file.c
@@ -137,7 +137,9 @@ static FILE *get_output_file(stHash *target_to_file, const char *target_name, co
 
      Paf *paf;
      int64_t total_records = 0;
-     while((paf = paf_read(input, 0)) != NULL) {
+     int64_t paf_buffer_length = 100;
+     char *paf_buffer = st_malloc(sizeof(char) * paf_buffer_length);
+     while((paf = paf_read_with_buffer(input, 0, &paf_buffer, &paf_buffer_length)) != NULL) {
          char *contig_name = split_by_query ? paf->query_name : paf->target_name;
          int64_t contig_length = split_by_query ? paf->query_length : paf->target_length;
          FILE *output;
@@ -165,10 +167,11 @@ static FILE *get_output_file(stHash *target_to_file, const char *target_name, co
          } else {
              output = get_output_file(contig_to_file, contig_name, prefix);
          }
-         paf_write(paf, output);
+         paf_write_with_buffer(paf, output, &paf_buffer, &paf_buffer_length);
          total_records++;
          paf_destruct(paf);
      }
+     free(paf_buffer);
 
      //////////////////////////////////////////////
      // Cleanup

--- a/impl/paf_tile.c
+++ b/impl/paf_tile.c
@@ -34,11 +34,11 @@ static int paf_cmp_by_descending_score(const void *a, const void *b) {
 }
 
 static int64_t get_median_alignment_level(uint16_t *counts, Paf *paf) {
-    Cigar *c = paf->cigar;
     int64_t i = paf->query_start, max_level=0, matches=0;
     int64_t *level_counts = st_calloc(UINT16_MAX, sizeof(int64_t)); // An array of counts of the number of bases with the given alignment level
     // such that level_counts[i] is the number of bases in the query with level_counts[i] number of alignments to it (at this point in the tiling)
-    while(c != NULL) {
+    for(int64_t ci = 0; ci < cigar_count(paf->cigar); ci++) {
+        CigarRecord *c = cigar_get(paf->cigar, ci);
         if(c->op != query_delete) {
             if(c->op != query_insert) { // is a match or mismatch, but not an insert in the query
                 assert(c->op == match || c->op == sequence_match || c->op == sequence_mismatch);
@@ -54,7 +54,6 @@ static int64_t get_median_alignment_level(uint16_t *counts, Paf *paf) {
             }
             i += c->length;
         }
-        c = c->next;
     }
     assert(i == paf->query_end);
 

--- a/impl/paf_to_bed.c
+++ b/impl/paf_to_bed.c
@@ -164,7 +164,9 @@ int paffy_to_bed_main(int argc, char *argv[]) {
 
     // For each alignment: increase by one the aligned bases count of each base covered by the alignment.
     Paf *paf;
-    while((paf = paf_read(input, 1)) != NULL) {
+    int64_t paf_buffer_length = 100;
+    char *paf_buffer = st_malloc(sizeof(char) * paf_buffer_length);
+    while((paf = paf_read_with_buffer(input, 1, &paf_buffer, &paf_buffer_length)) != NULL) {
         SequenceCountArray *seq_count_array = get_alignment_count_array(seq_names_to_alignment_count_arrays, paf);
         increase_alignment_level_counts(seq_count_array, paf);
 
@@ -176,6 +178,7 @@ int paffy_to_bed_main(int argc, char *argv[]) {
 
         paf_destruct(paf); // Cleanup the old paf record
     }
+    free(paf_buffer);
 
     // Output local alignments file, sorted by score from best-to-worst
     write_bed(output, seq_names_to_alignment_count_arrays, binary, exclude_unaligned, exclude_aligned, min_size);

--- a/impl/paf_trim.c
+++ b/impl/paf_trim.c
@@ -111,7 +111,9 @@ static void usage(void) {
      FILE *output = outputFile == NULL ? stdout : fopen(outputFile, "w");
 
      Paf *paf;
-     while((paf = paf_read(input, 1)) != NULL) {
+     int64_t paf_buffer_length = 100;
+     char *paf_buffer = st_malloc(sizeof(char) * paf_buffer_length);
+     while((paf = paf_read_with_buffer(input, 1, &paf_buffer, &paf_buffer_length)) != NULL) {
          if(trim_by_identity) {
              paf_trim_unreliable_tails(paf, trim_by_identity_fraction, trim_end_fraction);
          }
@@ -120,9 +122,10 @@ static void usage(void) {
          }
 
          paf_check(paf);
-         paf_write(paf, output);
+         paf_write_with_buffer(paf, output, &paf_buffer, &paf_buffer_length);
          paf_destruct(paf);
      }
+     free(paf_buffer);
 
      //////////////////////////////////////////////
      // Cleanup

--- a/impl/paf_upconvert.c
+++ b/impl/paf_upconvert.c
@@ -143,17 +143,20 @@ int paffy_upconvert_main(int argc, char *argv[]) {
     FILE *input = paf_file == NULL ? stdin : fopen(paf_file, "r");
     FILE *output = output_file == NULL ? stdout : fopen(output_file, "w");
     Paf *paf;
-    while((paf = paf_read(input, 0)) != NULL) {
+    int64_t paf_buffer_length = 100;
+    char *paf_buffer = st_malloc(sizeof(char) * paf_buffer_length);
+    while((paf = paf_read_with_buffer(input, 0, &paf_buffer, &paf_buffer_length)) != NULL) {
         // fix query and target coordinates
         fix_interval(intervals, &(paf->query_name), &(paf->query_start), &(paf->query_end), &(paf->query_length));
         fix_interval(intervals, &(paf->target_name), &(paf->target_start), &(paf->target_end), &(paf->target_length));
 
         paf_check(paf); // Check all is okay
 
-        paf_write(paf, output); // Write out the adjust paf
+        paf_write_with_buffer(paf, output, &paf_buffer, &paf_buffer_length); // Write out the adjust paf
 
         paf_destruct(paf); // Cleanup
     }
+    free(paf_buffer);
 
     //////////////////////////////////////////////
     // Cleanup

--- a/impl/paf_view.c
+++ b/impl/paf_view.c
@@ -146,7 +146,9 @@ int paffy_view_main(int argc, char *argv[]) {
     total_query_insert_bases=0, total_query_delete_bases=0;
 
     Paf *paf;
-    while((paf = paf_read(input, 1)) != NULL) {
+    int64_t paf_buffer_length = 100;
+    char *paf_buffer = st_malloc(sizeof(char) * paf_buffer_length);
+    while((paf = paf_read_with_buffer(input, 1, &paf_buffer, &paf_buffer_length)) != NULL) {
         // Get the query sequence
         char *query_seq = stHash_search(sequences, paf->query_name);
         if(query_seq == NULL) {
@@ -179,6 +181,7 @@ int paffy_view_main(int argc, char *argv[]) {
         // Cleanup
         paf_destruct(paf);
     }
+    free(paf_buffer);
 
     if(include_aggregate_stats) {
         fprintf(output, "Total-alignments:%" PRIi64"\tAvg-Identity:%f\tAvg-Identity-with-gaps:%f\tAligned-bases:%"

--- a/inc/paf.h
+++ b/inc/paf.h
@@ -118,6 +118,12 @@ Paf *paf_read(FILE *fh, bool parse_cigar_string);
 Paf *paf_read2(FILE *fh);
 
 /*
+ * Read a PAF alignment record from the given file. Returns NULL if no record available. Uses given string buffer to avoid
+ * malloc. Is not thread safe for the given file handle.
+ */
+Paf *paf_read_with_buffer(FILE *fh, bool parse_cigar_string, char **paf_buffer, int64_t *paf_length_buffer);
+
+/*
  * Prints a paf record
  */
 char *paf_print(Paf *paf);
@@ -137,6 +143,12 @@ void paf_pretty_print(Paf *paf, char *query_seq, char *target_seq, FILE *fh, boo
  * Writes a PAF alignment to the given file.
  */
 void paf_write(Paf *paf, FILE *fh);
+
+/*
+ * As paf_write, but using a provided buffer to avoid malloc.
+ */
+void paf_write_with_buffer(Paf *paf, FILE *fh, char **paf_buffer, int64_t *paf_length_buffer);
+
 
 /*
  * Checks a paf alignment coordinates and cigar are valid, error aborts if not.

--- a/inc/paf.h
+++ b/inc/paf.h
@@ -57,12 +57,23 @@ typedef enum _cigarOp {
     sequence_mismatch = 4 // representing a mismatch - represented using an X symbol
 } CigarOp;
 
-typedef struct _cigar Cigar;
-struct _cigar {
-    Cigar *next;
+// 8-byte element (same bitfield packing, no pointer)
+typedef struct _cigar_record {
     int64_t length : 56;
     int64_t op : 8;
+} CigarRecord;
+
+// Array container
+typedef struct _cigar Cigar;
+struct _cigar {
+    CigarRecord *recs;   // Contiguous array
+    int64_t length;      // Number of active elements
+    int64_t start;       // Offset for O(1) prefix trimming
+    int64_t capacity;    // Allocated slots in recs
 };
+
+static inline int64_t cigar_count(Cigar *c) { return c ? c->length : 0; }
+static inline CigarRecord *cigar_get(Cigar *c, int64_t i) { return &c->recs[c->start + i]; }
 
 /*
  * Convert a cigar string into a linked list of cigar operations

--- a/include.mk
+++ b/include.mk
@@ -35,9 +35,15 @@ ifndef TARGETOS
   TARGETOS := $(shell uname -s)
 endif
 
-# Hack to include openmp on os x after "brew install lomp
+# Hack to include openmp on os x after "brew install libomp"
 ifeq ($(TARGETOS), Darwin)
-	CFLAGS+= -Xpreprocessor -fopenmp -lomp
+	LIBOMP_PREFIX := $(shell brew --prefix libomp 2>/dev/null)
+	ifneq ($(LIBOMP_PREFIX),)
+		CFLAGS+= -I$(LIBOMP_PREFIX)/include -Xpreprocessor -fopenmp
+		LDLIBS+= -L$(LIBOMP_PREFIX)/lib -lomp
+	else
+		CFLAGS+= -Xpreprocessor -fopenmp -lomp
+	endif
 else
 	CFLAGS+= -fopenmp
 endif
@@ -48,6 +54,9 @@ ifeq ($(shell uname -m || true), aarch64)
 	arm=1
 endif
 ifeq ($(shell arch || true), aarch64)
+	arm=1
+endif
+ifeq ($(shell uname -m || true), arm64)
 	arm=1
 endif
 ifdef arm

--- a/paffy_main.c
+++ b/paffy_main.c
@@ -20,6 +20,7 @@ extern int paffy_trim_main(int argc, char *argv[]);
 extern int paffy_upconvert_main(int argc, char *argv[]);
 extern int paffy_view_main(int argc, char *argv[]);
 extern int paffy_filter_main(int argc, char *argv[]);
+extern int paffy_split_file_main(int argc, char *argv[]);
 
 void usage(void) {
     fprintf(stderr, "paffy: toolkit for working with PAF files\n\n");
@@ -37,6 +38,7 @@ void usage(void) {
     fprintf(stderr, "    to_bed                   Build an alignment coverage map of a chosen sequence in BED format\n");
     fprintf(stderr, "    trim                     Slice of lower identity tail alignments\n");
     fprintf(stderr, "    upconvert                Converts the coordinates of paf alignments to refer to extracted subsequences\n");
+    fprintf(stderr, "    split_file               Split PAF file into per-target-contig output files\n");
     fprintf(stderr, "    view                     Pretty print and extract stats about PAF alignments\n");
     fprintf(stderr, "\n");
 }
@@ -69,6 +71,8 @@ int main(int argc, char *argv[]) {
         return paffy_trim_main(argc - 1, argv + 1);
     } else if (strcmp(argv[1], "upconvert") == 0) {
         return paffy_upconvert_main(argc - 1, argv + 1);
+    } else if (strcmp(argv[1], "split_file") == 0) {
+        return paffy_split_file_main(argc - 1, argv + 1);
     } else if (strcmp(argv[1], "view") == 0) {
         return paffy_view_main(argc - 1, argv + 1);
     } else {

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ files.
 Do build this repo clone the repo as follows and then make:
 
     git clone https://github.com/ComparativeGenomicsToolkit/paffy.git --recursive
-    cd paf && make
+    cd paffy && make
 
 To test the installation, after adding the paffy/bin directory to your path, do:
 
@@ -37,6 +37,8 @@ All Paffy utilities are run using `paffy <command>`, where the available command
     dedupe         Remove duplicate alignments from a file based on exact query/target coordinates
     dechunk        Manipulate coordinates to allow aggregation of PAFs computed over subsequences
     upconvert      Converts the coordinates of paf alignments to refer to extracted subsequences
+    split_file     Split a PAF file into separate output files by target contig name. Optionally
+                   group small contigs (below a given target length threshold) into size-bounded files
 ```
 
 In addition the FASTA utilities are run using the `faffy <command>`, where the available commands are:

--- a/tests/allTests.c
+++ b/tests/allTests.c
@@ -8,6 +8,7 @@
 CuSuite* addPafTestSuite(void);
 CuSuite* addFastaExtractTestSuite(void);
 CuSuite* addFastaChunkAndMergeTestSuite(void);
+CuSuite* addPafSplitFileTestSuite(void);
 
 int cactusPafRunAllTests(void) {
     CuString *output = CuStringNew();
@@ -16,6 +17,7 @@ int cactusPafRunAllTests(void) {
     CuSuiteAddSuite(suite, addFastaExtractTestSuite());
     CuSuiteAddSuite(suite, addFastaChunkAndMergeTestSuite());
     CuSuiteAddSuite(suite, addPafTestSuite());
+    CuSuiteAddSuite(suite, addPafSplitFileTestSuite());
     CuSuiteRun(suite);
     CuSuiteSummary(suite, output);
     CuSuiteDetails(suite, output);

--- a/tests/allTests.c
+++ b/tests/allTests.c
@@ -9,6 +9,7 @@ CuSuite* addPafTestSuite(void);
 CuSuite* addFastaExtractTestSuite(void);
 CuSuite* addFastaChunkAndMergeTestSuite(void);
 CuSuite* addPafSplitFileTestSuite(void);
+CuSuite* addPafUnitTestSuite(void);
 
 int cactusPafRunAllTests(void) {
     CuString *output = CuStringNew();
@@ -18,6 +19,7 @@ int cactusPafRunAllTests(void) {
     CuSuiteAddSuite(suite, addFastaChunkAndMergeTestSuite());
     CuSuiteAddSuite(suite, addPafTestSuite());
     CuSuiteAddSuite(suite, addPafSplitFileTestSuite());
+    CuSuiteAddSuite(suite, addPafUnitTestSuite());
     CuSuiteRun(suite);
     CuSuiteSummary(suite, output);
     CuSuiteDetails(suite, output);

--- a/tests/paf_split_file_test.c
+++ b/tests/paf_split_file_test.c
@@ -1,0 +1,291 @@
+#include "paf.h"
+#include "CuTest.h"
+#include "sonLib.h"
+
+/*
+ * Unit tests for paffy split_file
+ */
+
+static void write_test_paf_file(const char *path) {
+    FILE *fh = fopen(path, "w");
+    assert(fh != NULL);
+    fprintf(fh, "q1\t100\t0\t50\t+\tchr1\t1000\t0\t50\t50\t50\t60\n");
+    fprintf(fh, "q2\t100\t0\t50\t+\tchr2\t500\t0\t50\t50\t50\t60\n");
+    fprintf(fh, "q3\t100\t0\t50\t-\tchr1\t1000\t100\t150\t50\t50\t60\n");
+    fprintf(fh, "q4\t100\t0\t50\t+\tsmall_a\t300\t0\t50\t50\t50\t60\n");
+    fprintf(fh, "q5\t100\t0\t50\t+\tsmall_b\t200\t0\t50\t50\t50\t60\n");
+    fprintf(fh, "q6\t100\t0\t50\t+\tsmall_c\t400\t0\t50\t50\t50\t60\n");
+    fprintf(fh, "q7\t100\t0\t50\t+\tsmall_a\t300\t50\t100\t50\t50\t60\n");
+    fprintf(fh, "q8\t100\t0\t50\t+\tsmall_d\t150\t0\t50\t50\t50\t60\n");
+    fclose(fh);
+}
+
+static int file_exists(const char *path) {
+    FILE *fh = fopen(path, "r");
+    if (fh != NULL) {
+        fclose(fh);
+        return 1;
+    }
+    return 0;
+}
+
+static int count_records(const char *path) {
+    FILE *fh = fopen(path, "r");
+    if (fh == NULL) return -1;
+    stList *pafs = read_pafs(fh, 0);
+    int count = stList_length(pafs);
+    fclose(fh);
+    stList_destruct(pafs);
+    return count;
+}
+
+static void test_split_file_basic(CuTest *testCase) {
+    // Write test PAF
+    const char *input = "./tests/temp_split_input.paf";
+    const char *prefix = "./tests/temp_split_";
+    write_test_paf_file(input);
+
+    // Run split_file with no minTargetLength
+    CuAssertTrue(testCase, st_system("./bin/paffy split_file -i %s -p %s", input, prefix) == 0);
+
+    // Verify all expected files exist
+    CuAssertTrue(testCase, file_exists("./tests/temp_split_chr1.paf"));
+    CuAssertTrue(testCase, file_exists("./tests/temp_split_chr2.paf"));
+    CuAssertTrue(testCase, file_exists("./tests/temp_split_small_a.paf"));
+    CuAssertTrue(testCase, file_exists("./tests/temp_split_small_b.paf"));
+    CuAssertTrue(testCase, file_exists("./tests/temp_split_small_c.paf"));
+    CuAssertTrue(testCase, file_exists("./tests/temp_split_small_d.paf"));
+
+    // Verify record counts
+    CuAssertIntEquals(testCase, 2, count_records("./tests/temp_split_chr1.paf"));
+    CuAssertIntEquals(testCase, 1, count_records("./tests/temp_split_chr2.paf"));
+    CuAssertIntEquals(testCase, 2, count_records("./tests/temp_split_small_a.paf"));
+    CuAssertIntEquals(testCase, 1, count_records("./tests/temp_split_small_b.paf"));
+    CuAssertIntEquals(testCase, 1, count_records("./tests/temp_split_small_c.paf"));
+    CuAssertIntEquals(testCase, 1, count_records("./tests/temp_split_small_d.paf"));
+
+    // Verify target names in chr1 file
+    FILE *fh = fopen("./tests/temp_split_chr1.paf", "r");
+    stList *pafs = read_pafs(fh, 0);
+    fclose(fh);
+    for (int64_t i = 0; i < stList_length(pafs); i++) {
+        Paf *paf = stList_get(pafs, i);
+        CuAssertTrue(testCase, strcmp(paf->target_name, "chr1") == 0);
+    }
+    stList_destruct(pafs);
+
+    // Verify target names in small_a file
+    fh = fopen("./tests/temp_split_small_a.paf", "r");
+    pafs = read_pafs(fh, 0);
+    fclose(fh);
+    CuAssertIntEquals(testCase, 2, stList_length(pafs));
+    for (int64_t i = 0; i < stList_length(pafs); i++) {
+        Paf *paf = stList_get(pafs, i);
+        CuAssertTrue(testCase, strcmp(paf->target_name, "small_a") == 0);
+    }
+    stList_destruct(pafs);
+
+    // Total records across all files
+    int total = count_records("./tests/temp_split_chr1.paf") +
+                count_records("./tests/temp_split_chr2.paf") +
+                count_records("./tests/temp_split_small_a.paf") +
+                count_records("./tests/temp_split_small_b.paf") +
+                count_records("./tests/temp_split_small_c.paf") +
+                count_records("./tests/temp_split_small_d.paf");
+    CuAssertIntEquals(testCase, 8, total);
+
+    // Cleanup
+    st_system("rm -f ./tests/temp_split_input.paf ./tests/temp_split_chr1.paf "
+              "./tests/temp_split_chr2.paf ./tests/temp_split_small_a.paf "
+              "./tests/temp_split_small_b.paf ./tests/temp_split_small_c.paf "
+              "./tests/temp_split_small_d.paf");
+}
+
+static void test_split_file_min_target_length(CuTest *testCase) {
+    // Write test PAF
+    const char *input = "./tests/temp_split_input.paf";
+    const char *prefix = "./tests/temp_split_";
+    write_test_paf_file(input);
+
+    // Run split_file with -m 500
+    CuAssertTrue(testCase, st_system("./bin/paffy split_file -i %s -p %s -m 500", input, prefix) == 0);
+
+    // Large contigs get their own files
+    CuAssertTrue(testCase, file_exists("./tests/temp_split_chr1.paf"));
+    CuAssertTrue(testCase, file_exists("./tests/temp_split_chr2.paf"));
+    CuAssertIntEquals(testCase, 2, count_records("./tests/temp_split_chr1.paf"));
+    CuAssertIntEquals(testCase, 1, count_records("./tests/temp_split_chr2.paf"));
+
+    // Small contigs are grouped into small_N files
+    CuAssertTrue(testCase, file_exists("./tests/temp_split_small_0.paf"));
+    CuAssertTrue(testCase, file_exists("./tests/temp_split_small_1.paf"));
+    CuAssertTrue(testCase, file_exists("./tests/temp_split_small_2.paf"));
+
+    // Per-target files should NOT exist for small contigs
+    CuAssertTrue(testCase, !file_exists("./tests/temp_split_small_a.paf"));
+    CuAssertTrue(testCase, !file_exists("./tests/temp_split_small_b.paf"));
+    CuAssertTrue(testCase, !file_exists("./tests/temp_split_small_c.paf"));
+    CuAssertTrue(testCase, !file_exists("./tests/temp_split_small_d.paf"));
+
+    // Verify small_0 has small_a (300) + small_b (200) = 3 records (q4, q5, q7)
+    CuAssertIntEquals(testCase, 3, count_records("./tests/temp_split_small_0.paf"));
+
+    // Verify small_1 has small_c (400) = 1 record (q6)
+    CuAssertIntEquals(testCase, 1, count_records("./tests/temp_split_small_1.paf"));
+
+    // Verify small_2 has small_d (150) = 1 record (q8)
+    CuAssertIntEquals(testCase, 1, count_records("./tests/temp_split_small_2.paf"));
+
+    // Verify all records in small_0 have target_name in {small_a, small_b}
+    FILE *fh = fopen("./tests/temp_split_small_0.paf", "r");
+    stList *pafs = read_pafs(fh, 0);
+    fclose(fh);
+    for (int64_t i = 0; i < stList_length(pafs); i++) {
+        Paf *paf = stList_get(pafs, i);
+        CuAssertTrue(testCase, strcmp(paf->target_name, "small_a") == 0 ||
+                               strcmp(paf->target_name, "small_b") == 0);
+    }
+    stList_destruct(pafs);
+
+    // Verify both small_a records (q4, q7) are in small_0 (contig locality preserved)
+    fh = fopen("./tests/temp_split_small_0.paf", "r");
+    pafs = read_pafs(fh, 0);
+    fclose(fh);
+    int small_a_count = 0;
+    for (int64_t i = 0; i < stList_length(pafs); i++) {
+        Paf *paf = stList_get(pafs, i);
+        if (strcmp(paf->target_name, "small_a") == 0) {
+            small_a_count++;
+        }
+    }
+    CuAssertIntEquals(testCase, 2, small_a_count);
+    stList_destruct(pafs);
+
+    // Cleanup
+    st_system("rm -f ./tests/temp_split_input.paf ./tests/temp_split_chr1.paf "
+              "./tests/temp_split_chr2.paf ./tests/temp_split_small_0.paf "
+              "./tests/temp_split_small_1.paf ./tests/temp_split_small_2.paf");
+}
+
+static void test_split_file_all_small(CuTest *testCase) {
+    // Write a PAF with only small contigs
+    const char *input = "./tests/temp_split_input.paf";
+    const char *prefix = "./tests/temp_split_";
+    FILE *fh = fopen(input, "w");
+    assert(fh != NULL);
+    fprintf(fh, "q1\t100\t0\t50\t+\tctg1\t100\t0\t50\t50\t50\t60\n");
+    fprintf(fh, "q2\t100\t0\t50\t+\tctg2\t100\t0\t50\t50\t50\t60\n");
+    fprintf(fh, "q3\t100\t0\t50\t+\tctg3\t100\t0\t50\t50\t50\t60\n");
+    fclose(fh);
+
+    // Run with -m 250: ctg1(100)+ctg2(100)=200<=250 -> small_0, ctg3(100): 200+100=300>250 -> small_1
+    CuAssertTrue(testCase, st_system("./bin/paffy split_file -i %s -p %s -m 250", input, prefix) == 0);
+
+    // Should have small_0 and small_1
+    CuAssertTrue(testCase, file_exists("./tests/temp_split_small_0.paf"));
+    CuAssertTrue(testCase, file_exists("./tests/temp_split_small_1.paf"));
+
+    CuAssertIntEquals(testCase, 2, count_records("./tests/temp_split_small_0.paf"));
+    CuAssertIntEquals(testCase, 1, count_records("./tests/temp_split_small_1.paf"));
+
+    // No per-target files should exist
+    CuAssertTrue(testCase, !file_exists("./tests/temp_split_ctg1.paf"));
+    CuAssertTrue(testCase, !file_exists("./tests/temp_split_ctg2.paf"));
+    CuAssertTrue(testCase, !file_exists("./tests/temp_split_ctg3.paf"));
+
+    // Cleanup
+    st_system("rm -f ./tests/temp_split_input.paf ./tests/temp_split_small_0.paf "
+              "./tests/temp_split_small_1.paf");
+}
+
+static void test_split_file_empty_input(CuTest *testCase) {
+    // Write an empty file
+    const char *input = "./tests/temp_split_input.paf";
+    const char *prefix = "./tests/temp_split_empty_";
+    FILE *fh = fopen(input, "w");
+    assert(fh != NULL);
+    fclose(fh);
+
+    // Run split_file
+    CuAssertTrue(testCase, st_system("./bin/paffy split_file -i %s -p %s", input, prefix) == 0);
+
+    // No output files should be created - verify a few likely names don't exist
+    CuAssertTrue(testCase, !file_exists("./tests/temp_split_empty_small_0.paf"));
+
+    // Cleanup
+    st_system("rm -f ./tests/temp_split_input.paf");
+}
+
+static void test_split_file_single_target(CuTest *testCase) {
+    // Write PAF with 3 records all targeting chrX
+    const char *input = "./tests/temp_split_input.paf";
+    const char *prefix = "./tests/temp_split_";
+    FILE *fh = fopen(input, "w");
+    assert(fh != NULL);
+    fprintf(fh, "q1\t100\t0\t50\t+\tchrX\t5000\t0\t50\t50\t50\t60\n");
+    fprintf(fh, "q2\t100\t0\t50\t+\tchrX\t5000\t100\t150\t50\t50\t60\n");
+    fprintf(fh, "q3\t100\t0\t50\t-\tchrX\t5000\t200\t250\t50\t50\t60\n");
+    fclose(fh);
+
+    // Run split_file
+    CuAssertTrue(testCase, st_system("./bin/paffy split_file -i %s -p %s", input, prefix) == 0);
+
+    // Exactly one output file
+    CuAssertTrue(testCase, file_exists("./tests/temp_split_chrX.paf"));
+    CuAssertIntEquals(testCase, 3, count_records("./tests/temp_split_chrX.paf"));
+
+    // Verify all records have target_name chrX
+    fh = fopen("./tests/temp_split_chrX.paf", "r");
+    stList *pafs = read_pafs(fh, 0);
+    fclose(fh);
+    for (int64_t i = 0; i < stList_length(pafs); i++) {
+        Paf *paf = stList_get(pafs, i);
+        CuAssertTrue(testCase, strcmp(paf->target_name, "chrX") == 0);
+    }
+    stList_destruct(pafs);
+
+    // Cleanup
+    st_system("rm -f ./tests/temp_split_input.paf ./tests/temp_split_chrX.paf");
+}
+
+static void test_split_file_sanitize_filename(CuTest *testCase) {
+    // Write PAF with a target name containing '/'
+    const char *input = "./tests/temp_split_input.paf";
+    const char *prefix = "./tests/temp_split_";
+    FILE *fh = fopen(input, "w");
+    assert(fh != NULL);
+    fprintf(fh, "q1\t100\t0\t50\t+\tcontig/scaffold_1\t2000\t0\t50\t50\t50\t60\n");
+    fprintf(fh, "q2\t100\t0\t50\t+\tcontig/scaffold_1\t2000\t100\t150\t50\t50\t60\n");
+    fclose(fh);
+
+    // Run split_file
+    CuAssertTrue(testCase, st_system("./bin/paffy split_file -i %s -p %s", input, prefix) == 0);
+
+    // Slashes should be replaced with underscores in filename
+    CuAssertTrue(testCase, file_exists("./tests/temp_split_contig_scaffold_1.paf"));
+    CuAssertIntEquals(testCase, 2, count_records("./tests/temp_split_contig_scaffold_1.paf"));
+
+    // Verify the original target_name is preserved in the records
+    fh = fopen("./tests/temp_split_contig_scaffold_1.paf", "r");
+    stList *pafs = read_pafs(fh, 0);
+    fclose(fh);
+    for (int64_t i = 0; i < stList_length(pafs); i++) {
+        Paf *paf = stList_get(pafs, i);
+        CuAssertTrue(testCase, strcmp(paf->target_name, "contig/scaffold_1") == 0);
+    }
+    stList_destruct(pafs);
+
+    // Cleanup
+    st_system("rm -f ./tests/temp_split_input.paf ./tests/temp_split_contig_scaffold_1.paf");
+}
+
+CuSuite* addPafSplitFileTestSuite(void) {
+    CuSuite* suite = CuSuiteNew();
+    SUITE_ADD_TEST(suite, test_split_file_basic);
+    SUITE_ADD_TEST(suite, test_split_file_min_target_length);
+    SUITE_ADD_TEST(suite, test_split_file_all_small);
+    SUITE_ADD_TEST(suite, test_split_file_empty_input);
+    SUITE_ADD_TEST(suite, test_split_file_single_target);
+    SUITE_ADD_TEST(suite, test_split_file_sanitize_filename);
+    return suite;
+}

--- a/tests/paf_tools_test.sh
+++ b/tests/paf_tools_test.sh
@@ -66,3 +66,56 @@ paffy filter -i ${working_dir}/output.paf -t 10000 | paffy view ${working_dir}/*
 # Run paffy view with filter (inverted)
 echo "paffy filter removing alignments with score >= than 10000"
 paffy filter -i ${working_dir}/output.paf -t 10000 -x | paffy view ${working_dir}/*.fa -s -t -u 0.74 -v 15000
+
+# Run paffy to_bed basic
+echo "paffy to_bed basic output"
+paffy to_bed -i ${working_dir}/output.paf -o ${working_dir}/output.bed
+[ -s ${working_dir}/output.bed ]
+
+# Run paffy to_bed -b (binary: 4th column must be 0 or 1)
+echo "paffy to_bed binary output"
+paffy to_bed -i ${working_dir}/output.paf -b -o ${working_dir}/output_binary.bed
+[ -s ${working_dir}/output_binary.bed ]
+awk '{if ($4 > 1) exit 1}' ${working_dir}/output_binary.bed
+
+# Run paffy to_bed -e (exclude unaligned: all output rows must have count > 0)
+echo "paffy to_bed exclude unaligned"
+paffy to_bed -i ${working_dir}/output.paf -e -o ${working_dir}/output_no_unaligned.bed
+[ -s ${working_dir}/output_no_unaligned.bed ]
+awk '{if ($4 == 0) exit 1}' ${working_dir}/output_no_unaligned.bed
+
+# Run paffy to_bed -f (exclude aligned: all output rows must have count == 0)
+echo "paffy to_bed exclude aligned"
+paffy to_bed -i ${working_dir}/output.paf -f -o ${working_dir}/output_unaligned_only.bed
+awk '{if ($4 != 0) exit 1}' ${working_dir}/output_unaligned_only.bed
+
+# Run paffy to_bed -n (include inverted: flips alignments so target seqs are also covered)
+echo "paffy to_bed include inverted"
+lines_non_inv=$(paffy to_bed -i ${working_dir}/output.paf -e | wc -l)
+lines_inv=$(paffy to_bed -i ${working_dir}/output.paf -e -n | wc -l)
+[ "${lines_inv}" -ge "${lines_non_inv}" ]
+
+# Run paffy filter -u (min identity after encoding mismatches)
+echo "paffy filter by min identity"
+paffy add_mismatches -i ${working_dir}/output.paf ${working_dir}/*.fa \
+  | paffy filter -u 0.7 > /dev/null
+
+# Run paffy filter -v (min identity with gaps after encoding mismatches)
+echo "paffy filter by min identity with gaps"
+paffy add_mismatches -i ${working_dir}/output.paf ${working_dir}/*.fa \
+  | paffy filter -v 0.7 > /dev/null
+
+# Run paffy filter -w (max tile level after tile)
+echo "paffy filter by max tile level"
+paffy tile -i ${working_dir}/output.paf | paffy filter -w 1 > /dev/null
+
+# Run paffy trim -f (fixed trim: constant fraction from each end)
+# Fixed trim reduces total aligned bases and slightly lowers identity, so use a relaxed -u threshold
+echo "paffy trim fixed trim"
+paffy trim -f -t 0.1 -i ${working_dir}/output.paf | paffy view ${working_dir}/*.fa -s -t -u 0.73 -v 450000
+
+# Run paffy dedupe -a (check inverse: also deduplicate inverted alignments)
+echo "paffy dedupe check inverse"
+paffy invert -i ${working_dir}/output.paf > ${working_dir}/output_inv.paf
+cat ${working_dir}/output.paf ${working_dir}/output_inv.paf \
+  | paffy dedupe -a | paffy view ${working_dir}/*.fa -s -t -u 0.74 -v 530000

--- a/tests/paf_unit_test.c
+++ b/tests/paf_unit_test.c
@@ -1,0 +1,672 @@
+/*
+ * Unit tests for individual paf.h API functions.
+ */
+
+#include "paf.h"
+#include "CuTest.h"
+#include "sonLib.h"
+
+/* ---- helpers ---- */
+
+/* paf_parse modifies its input (strtok_r), so always pass a copy */
+static Paf *parse_str(const char *s, bool cigar) {
+    char *copy = stString_copy(s);
+    Paf *p = paf_parse(copy, cigar);
+    free(copy);
+    return p;
+}
+
+/* Build a PAF record programmatically */
+static Paf *make_paf(const char *qname, int64_t qlen, int64_t qs, int64_t qe,
+                     bool same_strand,
+                     const char *tname, int64_t tlen, int64_t ts, int64_t te,
+                     int64_t nm, int64_t nb, int64_t mq,
+                     const char *cigar_str) {
+    Paf *p = st_calloc(1, sizeof(Paf));
+    p->query_name   = stString_copy(qname);
+    p->query_length = qlen;
+    p->query_start  = qs;
+    p->query_end    = qe;
+    p->target_name   = stString_copy(tname);
+    p->target_length = tlen;
+    p->target_start  = ts;
+    p->target_end    = te;
+    p->same_strand   = same_strand;
+    p->num_matches   = nm;
+    p->num_bases     = nb;
+    p->mapping_quality = mq;
+    p->tile_level = -1;
+    p->chain_id   = -1;
+    p->chain_score = -1;
+    if (cigar_str) {
+        char *cs = stString_copy(cigar_str);
+        p->cigar = cigar_parse(cs);
+        free(cs);
+    }
+    return p;
+}
+
+/* ---- 1. Cigar parsing ---- */
+
+static void test_cigar_parse_empty(CuTest *tc) {
+    Cigar *c = cigar_parse("");
+    CuAssertTrue(tc, c == NULL);
+}
+
+static void test_cigar_parse_single(CuTest *tc) {
+    char s[] = "10M";
+    Cigar *c = cigar_parse(s);
+    CuAssertTrue(tc, c != NULL);
+    CuAssertIntEquals(tc, 1, cigar_count(c));
+    CuAssertIntEquals(tc, match, cigar_get(c, 0)->op);
+    CuAssertTrue(tc, cigar_get(c, 0)->length == 10);
+    cigar_destruct(c);
+}
+
+static void test_cigar_parse_all_ops(CuTest *tc) {
+    char s[] = "5M3I2D4=1X";
+    Cigar *c = cigar_parse(s);
+    CuAssertTrue(tc, c != NULL);
+    CuAssertIntEquals(tc, 5, cigar_count(c));
+    CuAssertIntEquals(tc, match,             cigar_get(c, 0)->op);
+    CuAssertTrue(tc, cigar_get(c, 0)->length == 5);
+    CuAssertIntEquals(tc, query_insert,      cigar_get(c, 1)->op);
+    CuAssertTrue(tc, cigar_get(c, 1)->length == 3);
+    CuAssertIntEquals(tc, query_delete,      cigar_get(c, 2)->op);
+    CuAssertTrue(tc, cigar_get(c, 2)->length == 2);
+    CuAssertIntEquals(tc, sequence_match,    cigar_get(c, 3)->op);
+    CuAssertTrue(tc, cigar_get(c, 3)->length == 4);
+    CuAssertIntEquals(tc, sequence_mismatch, cigar_get(c, 4)->op);
+    CuAssertTrue(tc, cigar_get(c, 4)->length == 1);
+    cigar_destruct(c);
+}
+
+static void test_cigar_parse_large_length(CuTest *tc) {
+    char s[] = "1000000M";
+    Cigar *c = cigar_parse(s);
+    CuAssertTrue(tc, c != NULL);
+    CuAssertIntEquals(tc, 1, cigar_count(c));
+    CuAssertTrue(tc, cigar_get(c, 0)->length == 1000000);
+    cigar_destruct(c);
+}
+
+/* ---- 2. Cigar accessors ---- */
+
+static void test_cigar_count_get(CuTest *tc) {
+    char s[] = "3M2I";
+    Cigar *c = cigar_parse(s);
+    CuAssertIntEquals(tc, 2, cigar_count(c));
+    CuAssertIntEquals(tc, match,        cigar_get(c, 0)->op);
+    CuAssertTrue(tc, cigar_get(c, 0)->length == 3);
+    CuAssertIntEquals(tc, query_insert, cigar_get(c, 1)->op);
+    CuAssertTrue(tc, cigar_get(c, 1)->length == 2);
+    /* NULL -> 0 */
+    CuAssertIntEquals(tc, 0, cigar_count(NULL));
+    cigar_destruct(c);
+}
+
+/* ---- 3. PAF parsing ---- */
+
+static void test_paf_parse_minimal(CuTest *tc) {
+    Paf *paf = parse_str(
+        "query1\t100\t0\t50\t+\ttarget1\t200\t10\t60\t50\t50\t255",
+        true);
+    CuAssertStrEquals(tc, "query1",  paf->query_name);
+    CuAssertTrue(tc, paf->query_length == 100);
+    CuAssertTrue(tc, paf->query_start  == 0);
+    CuAssertTrue(tc, paf->query_end    == 50);
+    CuAssertStrEquals(tc, "target1", paf->target_name);
+    CuAssertTrue(tc, paf->target_length == 200);
+    CuAssertTrue(tc, paf->target_start  == 10);
+    CuAssertTrue(tc, paf->target_end    == 60);
+    CuAssertTrue(tc, paf->num_matches   == 50);
+    CuAssertTrue(tc, paf->num_bases     == 50);
+    CuAssertTrue(tc, paf->mapping_quality == 255);
+    CuAssertTrue(tc, paf->same_strand == true);
+    CuAssertTrue(tc, paf->cigar        == NULL);
+    CuAssertTrue(tc, paf->cigar_string == NULL);
+    paf_destruct(paf);
+}
+
+static void test_paf_parse_with_cigar(CuTest *tc) {
+    /* query span: 5+3=8, target span: 5+2=7 */
+    Paf *paf = parse_str(
+        "q1\t100\t0\t8\t+\tt1\t200\t0\t7\t8\t10\t60\tcg:Z:5M3I2D",
+        true);
+    CuAssertTrue(tc, paf->cigar        != NULL);
+    CuAssertTrue(tc, paf->cigar_string == NULL);
+    CuAssertIntEquals(tc, 3, cigar_count(paf->cigar));
+    CuAssertIntEquals(tc, match,        cigar_get(paf->cigar, 0)->op);
+    CuAssertTrue(tc, cigar_get(paf->cigar, 0)->length == 5);
+    CuAssertIntEquals(tc, query_insert, cigar_get(paf->cigar, 1)->op);
+    CuAssertTrue(tc, cigar_get(paf->cigar, 1)->length == 3);
+    CuAssertIntEquals(tc, query_delete, cigar_get(paf->cigar, 2)->op);
+    CuAssertTrue(tc, cigar_get(paf->cigar, 2)->length == 2);
+    paf_destruct(paf);
+}
+
+static void test_paf_parse_cigar_string_mode(CuTest *tc) {
+    Paf *paf = parse_str(
+        "q1\t100\t0\t8\t+\tt1\t200\t0\t7\t8\t10\t60\tcg:Z:5M3I2D",
+        false);
+    CuAssertTrue(tc, paf->cigar        == NULL);
+    CuAssertTrue(tc, paf->cigar_string != NULL);
+    CuAssertStrEquals(tc, "5M3I2D", paf->cigar_string);
+    paf_destruct(paf);
+}
+
+static void test_paf_parse_optional_tags(CuTest *tc) {
+    Paf *paf = parse_str(
+        "q1\t100\t0\t50\t+\tt1\t200\t0\t50\t50\t50\t60\t"
+        "tp:A:P\tAS:i:42\ttl:i:2\tcn:i:5\ts1:i:100",
+        true);
+    CuAssertTrue(tc, paf->type        == 'P');
+    CuAssertTrue(tc, paf->score       == 42);
+    CuAssertTrue(tc, paf->tile_level  == 2);
+    CuAssertTrue(tc, paf->chain_id    == 5);
+    CuAssertTrue(tc, paf->chain_score == 100);
+    /* absent optional tags default to -1 */
+    paf_destruct(paf);
+}
+
+static void test_paf_parse_strand(CuTest *tc) {
+    Paf *pos = parse_str(
+        "q1\t100\t0\t50\t+\tt1\t200\t0\t50\t50\t50\t60", true);
+    CuAssertTrue(tc, pos->same_strand == true);
+    paf_destruct(pos);
+
+    Paf *neg = parse_str(
+        "q1\t100\t0\t50\t-\tt1\t200\t0\t50\t50\t50\t60", true);
+    CuAssertTrue(tc, neg->same_strand == false);
+    paf_destruct(neg);
+}
+
+/* ---- 4. Roundtrip ---- */
+
+static void test_paf_roundtrip_no_cigar(CuTest *tc) {
+    /* Parse, print, re-parse, re-print: second and third strings must match */
+    Paf *paf1 = parse_str(
+        "query1\t100\t0\t50\t+\ttarget1\t200\t10\t60\t50\t50\t255",
+        true);
+    char *s1      = paf_print(paf1);
+    char *s1_copy = stString_copy(s1);
+    free(s1);
+
+    Paf *paf2 = parse_str(s1_copy, true);
+    char *s2  = paf_print(paf2);
+
+    CuAssertStrEquals(tc, s1_copy, s2);
+    free(s1_copy);
+    free(s2);
+    paf_destruct(paf1);
+    paf_destruct(paf2);
+}
+
+static void test_paf_roundtrip_with_cigar(CuTest *tc) {
+    /* 5M3I2D: query span=8, target span=7 */
+    Paf *paf1 = parse_str(
+        "q1\t100\t0\t8\t+\tt1\t200\t0\t7\t8\t10\t60\tcg:Z:5M3I2D",
+        true);
+    char *s1      = paf_print(paf1);
+    char *s1_copy = stString_copy(s1);
+    free(s1);
+
+    Paf *paf2 = parse_str(s1_copy, true);
+    char *s2  = paf_print(paf2);
+
+    CuAssertStrEquals(tc, s1_copy, s2);
+    CuAssertIntEquals(tc, 3, cigar_count(paf2->cigar));
+    CuAssertIntEquals(tc, match,        cigar_get(paf2->cigar, 0)->op);
+    CuAssertTrue(tc, cigar_get(paf2->cigar, 0)->length == 5);
+    CuAssertIntEquals(tc, query_insert, cigar_get(paf2->cigar, 1)->op);
+    CuAssertTrue(tc, cigar_get(paf2->cigar, 1)->length == 3);
+    CuAssertIntEquals(tc, query_delete, cigar_get(paf2->cigar, 2)->op);
+    CuAssertTrue(tc, cigar_get(paf2->cigar, 2)->length == 2);
+
+    free(s1_copy);
+    free(s2);
+    paf_destruct(paf1);
+    paf_destruct(paf2);
+}
+
+/* ---- 5. File I/O ---- */
+
+static void test_paf_read_write(CuTest *tc) {
+    FILE *fh = tmpfile();
+    CuAssertTrue(tc, fh != NULL);
+
+    fprintf(fh, "q1\t100\t0\t50\t+\tt1\t200\t0\t50\t50\t50\t60\n");
+    fprintf(fh, "q2\t200\t10\t60\t-\tt2\t300\t20\t70\t50\t50\t30\n");
+    fprintf(fh, "q3\t150\t5\t55\t+\tt3\t250\t15\t65\t50\t50\t40\n");
+    rewind(fh);
+
+    Paf *p1   = paf_read2(fh);
+    Paf *p2   = paf_read2(fh);
+    Paf *p3   = paf_read2(fh);
+    Paf *pend = paf_read2(fh);
+
+    CuAssertTrue(tc, p1   != NULL);
+    CuAssertTrue(tc, p2   != NULL);
+    CuAssertTrue(tc, p3   != NULL);
+    CuAssertTrue(tc, pend == NULL);
+
+    CuAssertStrEquals(tc, "q1", p1->query_name);
+    CuAssertTrue(tc, p1->query_length == 100);
+    CuAssertTrue(tc, p1->same_strand  == true);
+
+    CuAssertStrEquals(tc, "q2", p2->query_name);
+    CuAssertTrue(tc, p2->same_strand == false);
+
+    CuAssertStrEquals(tc, "q3", p3->query_name);
+    CuAssertTrue(tc, p3->query_start == 5);
+
+    paf_destruct(p1);
+    paf_destruct(p2);
+    paf_destruct(p3);
+    fclose(fh);
+}
+
+static void test_read_write_pafs_list(CuTest *tc) {
+    stList *out = stList_construct3(0, (void(*)(void*))paf_destruct);
+    stList_append(out, make_paf("qa", 100, 0, 50, true,  "ta", 200, 0, 50, 50, 50, 60, NULL));
+    stList_append(out, make_paf("qb", 100, 0, 50, false, "tb", 200, 0, 50, 50, 50, 60, NULL));
+    stList_append(out, make_paf("qc", 100, 0, 50, true,  "tc", 200, 0, 50, 50, 50, 60, NULL));
+
+    FILE *fh = tmpfile();
+    CuAssertTrue(tc, fh != NULL);
+    write_pafs(fh, out);
+    rewind(fh);
+    stList *in = read_pafs(fh, false);
+    fclose(fh);
+
+    CuAssertIntEquals(tc, 3, stList_length(in));
+    CuAssertStrEquals(tc, "qa", ((Paf*)stList_get(in, 0))->query_name);
+    CuAssertTrue(tc, ((Paf*)stList_get(in, 0))->same_strand == true);
+    CuAssertStrEquals(tc, "qb", ((Paf*)stList_get(in, 1))->query_name);
+    CuAssertTrue(tc, ((Paf*)stList_get(in, 1))->same_strand == false);
+    CuAssertStrEquals(tc, "qc", ((Paf*)stList_get(in, 2))->query_name);
+
+    stList_destruct(out);
+    stList_destruct(in);
+}
+
+/* ---- 6. PAF Stats ---- */
+
+static void test_paf_stats_calc_all_match(CuTest *tc) {
+    Paf *paf = make_paf("q", 100, 0, 10, true, "t", 100, 0, 10, 10, 10, 60, "10M");
+    int64_t mat=0, mis=0, qi=0, qd=0, qib=0, qdb=0;
+    paf_stats_calc(paf, &mat, &mis, &qi, &qd, &qib, &qdb, true);
+    CuAssertTrue(tc, mat == 10);
+    CuAssertTrue(tc, mis == 0 && qi == 0 && qd == 0 && qib == 0 && qdb == 0);
+    paf_destruct(paf);
+}
+
+static void test_paf_stats_calc_mixed(CuTest *tc) {
+    /* "3=2X1I2D": query span=3+2+1=6, target span=3+2+2=7 */
+    Paf *paf = make_paf("q", 100, 0, 6, true, "t", 100, 0, 7, 5, 8, 60, "3=2X1I2D");
+    int64_t mat=0, mis=0, qi=0, qd=0, qib=0, qdb=0;
+    paf_stats_calc(paf, &mat, &mis, &qi, &qd, &qib, &qdb, true);
+    CuAssertTrue(tc, mat == 3);
+    CuAssertTrue(tc, mis == 2);
+    CuAssertTrue(tc, qi  == 1 && qib == 1);
+    CuAssertTrue(tc, qd  == 1 && qdb == 2);
+    paf_destruct(paf);
+}
+
+static void test_paf_stats_calc_zero_flag(CuTest *tc) {
+    Paf *paf = make_paf("q", 100, 0, 5, true, "t", 100, 0, 5, 5, 5, 60, "5M");
+    int64_t mat=0, mis=0, qi=0, qd=0, qib=0, qdb=0;
+
+    /* accumulate twice without zeroing */
+    paf_stats_calc(paf, &mat, &mis, &qi, &qd, &qib, &qdb, false);
+    paf_stats_calc(paf, &mat, &mis, &qi, &qd, &qib, &qdb, false);
+    CuAssertTrue(tc, mat == 10);
+
+    /* zero_counts=true resets before accumulating */
+    paf_stats_calc(paf, &mat, &mis, &qi, &qd, &qib, &qdb, true);
+    CuAssertTrue(tc, mat == 5);
+
+    paf_destruct(paf);
+}
+
+/* ---- 7. PAF Invert ---- */
+
+static void test_paf_invert_same_strand(CuTest *tc) {
+    /* 5M3I2D: query span=5+3=8, target span=5+2=7 */
+    Paf *paf = make_paf("query", 100, 10, 18, true, "target", 200, 20, 27, 8, 10, 60, "5M3I2D");
+    paf_invert(paf);
+
+    /* names swapped */
+    CuAssertStrEquals(tc, "target", paf->query_name);
+    CuAssertStrEquals(tc, "query",  paf->target_name);
+    /* coords swapped */
+    CuAssertTrue(tc, paf->query_start  == 20);
+    CuAssertTrue(tc, paf->query_end    == 27);
+    CuAssertTrue(tc, paf->query_length == 200);
+    CuAssertTrue(tc, paf->target_start  == 10);
+    CuAssertTrue(tc, paf->target_end    == 18);
+    CuAssertTrue(tc, paf->target_length == 100);
+    /* same_strand unchanged */
+    CuAssertTrue(tc, paf->same_strand == true);
+    /* I<->D swapped, order unchanged (same_strand) → 5M3D2I */
+    CuAssertIntEquals(tc, 3, cigar_count(paf->cigar));
+    CuAssertIntEquals(tc, match,        cigar_get(paf->cigar, 0)->op);
+    CuAssertTrue(tc, cigar_get(paf->cigar, 0)->length == 5);
+    CuAssertIntEquals(tc, query_delete, cigar_get(paf->cigar, 1)->op);
+    CuAssertTrue(tc, cigar_get(paf->cigar, 1)->length == 3);
+    CuAssertIntEquals(tc, query_insert, cigar_get(paf->cigar, 2)->op);
+    CuAssertTrue(tc, cigar_get(paf->cigar, 2)->length == 2);
+
+    paf_destruct(paf);
+}
+
+static void test_paf_invert_opposite_strand(CuTest *tc) {
+    /* 5M3I: query span=5+3=8, target span=5 */
+    Paf *paf = make_paf("query", 100, 10, 18, false, "target", 200, 20, 25, 5, 8, 60, "5M3I");
+    paf_invert(paf);
+
+    CuAssertTrue(tc, paf->same_strand == false);
+    CuAssertStrEquals(tc, "target", paf->query_name);
+    CuAssertStrEquals(tc, "query",  paf->target_name);
+
+    /* I<->D swapped and then reversed (opposite strand): 5M3D → reversed → 3D5M */
+    CuAssertIntEquals(tc, 2, cigar_count(paf->cigar));
+    CuAssertIntEquals(tc, query_delete, cigar_get(paf->cigar, 0)->op);
+    CuAssertTrue(tc, cigar_get(paf->cigar, 0)->length == 3);
+    CuAssertIntEquals(tc, match,        cigar_get(paf->cigar, 1)->op);
+    CuAssertTrue(tc, cigar_get(paf->cigar, 1)->length == 5);
+
+    paf_destruct(paf);
+}
+
+static void test_paf_invert_double(CuTest *tc) {
+    /* Double-invert must return to original state */
+    Paf *paf = make_paf("query", 100, 10, 18, true, "target", 200, 20, 27, 8, 10, 60, "5M3I2D");
+    char *orig = paf_print(paf);
+    paf_invert(paf);
+    paf_invert(paf);
+    char *trip = paf_print(paf);
+    CuAssertStrEquals(tc, orig, trip);
+    free(orig);
+    free(trip);
+    paf_destruct(paf);
+}
+
+/* ---- 8. Aligned base count ---- */
+
+static void test_aligned_bases(CuTest *tc) {
+    /* "5M3I2D4=1X": M+=X count, I/D excluded → 5+4+1=10 */
+    /* query span=5+3+4+1=13, target span=5+2+4+1=12 */
+    Paf *paf = make_paf("q", 100, 0, 13, true, "t", 100, 0, 12, 10, 15, 60, "5M3I2D4=1X");
+    CuAssertTrue(tc, paf_get_number_of_aligned_bases(paf) == 10);
+    paf_destruct(paf);
+}
+
+/* ---- 9. Trimming ---- */
+
+static void test_paf_trim_ends_zero(CuTest *tc) {
+    Paf *paf = make_paf("q", 100, 5, 15, true, "t", 100, 5, 15, 10, 10, 60, "10M");
+    paf_trim_ends(paf, 0);
+    CuAssertTrue(tc, paf->query_start  == 5);
+    CuAssertTrue(tc, paf->query_end    == 15);
+    CuAssertTrue(tc, paf->target_start == 5);
+    CuAssertTrue(tc, paf->target_end   == 15);
+    CuAssertIntEquals(tc, 1, cigar_count(paf->cigar));
+    CuAssertTrue(tc, cigar_get(paf->cigar, 0)->length == 10);
+    paf_destruct(paf);
+}
+
+static void test_paf_trim_ends_same_strand(CuTest *tc) {
+    /* 10M, trim 2 from each end → 6M remains */
+    Paf *paf = make_paf("q", 100, 0, 10, true, "t", 100, 0, 10, 10, 10, 60, "10M");
+    paf_trim_ends(paf, 2);
+    CuAssertTrue(tc, paf->query_start  == 2);
+    CuAssertTrue(tc, paf->query_end    == 8);
+    CuAssertTrue(tc, paf->target_start == 2);
+    CuAssertTrue(tc, paf->target_end   == 8);
+    CuAssertIntEquals(tc, 1, cigar_count(paf->cigar));
+    CuAssertTrue(tc, cigar_get(paf->cigar, 0)->length == 6);
+    paf_destruct(paf);
+}
+
+static void test_paf_trim_ends_with_gaps(CuTest *tc) {
+    /* "2M1I5M": query span=2+1+5=8, target span=2+5=7
+     * Front trim 3: consume 2M (2 aligned) + 1I (gap) + 1 base of 5M → 4M left
+     *   query_start += 2+1+1=4, target_start += 2+1=3
+     * Back trim 3 on 4M: remove 3 from back → 1M
+     *   query_end = 8-3=5, target_end = 7-3=4 */
+    Paf *paf = make_paf("q", 100, 0, 8, true, "t", 100, 0, 7, 7, 8, 60, "2M1I5M");
+    paf_trim_ends(paf, 3);
+    CuAssertTrue(tc, paf->query_start  == 4);
+    CuAssertTrue(tc, paf->target_start == 3);
+    CuAssertTrue(tc, paf->query_end    == 5);
+    CuAssertTrue(tc, paf->target_end   == 4);
+    paf_destruct(paf);
+}
+
+static void test_paf_trim_end_fraction(CuTest *tc) {
+    /* 10M, fraction=0.4 → end_trim = floor(10*0.4/2) = 2 */
+    Paf *paf = make_paf("q", 100, 0, 10, true, "t", 100, 0, 10, 10, 10, 60, "10M");
+    paf_trim_end_fraction(paf, 0.4f);
+    CuAssertTrue(tc, paf->query_start  == 2);
+    CuAssertTrue(tc, paf->query_end    == 8);
+    CuAssertTrue(tc, paf->target_start == 2);
+    CuAssertTrue(tc, paf->target_end   == 8);
+    paf_destruct(paf);
+}
+
+/* ---- 10. Shatter ---- */
+
+static void test_paf_shatter_single_match(CuTest *tc) {
+    Paf *paf = make_paf("q", 100, 0, 5, true, "t", 100, 0, 5, 5, 5, 60, "5M");
+    stList *shards = paf_shatter(paf);
+    CuAssertIntEquals(tc, 1, stList_length(shards));
+    Paf *s = stList_get(shards, 0);
+    CuAssertStrEquals(tc, "q", s->query_name);
+    CuAssertTrue(tc, s->query_start  == 0);
+    CuAssertTrue(tc, s->query_end    == 5);
+    CuAssertTrue(tc, s->target_start == 0);
+    CuAssertTrue(tc, s->target_end   == 5);
+    stList_destruct(shards);
+    paf_destruct(paf);
+}
+
+static void test_paf_shatter_multi_match(CuTest *tc) {
+    /* "3M2D4M": query span=3+4=7, target span=3+2+4=9 */
+    Paf *paf = make_paf("q", 100, 0, 7, true, "t", 100, 0, 9, 7, 9, 60, "3M2D4M");
+    stList *shards = paf_shatter(paf);
+    CuAssertIntEquals(tc, 2, stList_length(shards));
+
+    Paf *s0 = stList_get(shards, 0);
+    CuAssertTrue(tc, s0->query_start  == 0);
+    CuAssertTrue(tc, s0->query_end    == 3);
+    CuAssertTrue(tc, s0->target_start == 0);
+    CuAssertTrue(tc, s0->target_end   == 3);
+
+    /* target skips 2D gap: 3+2=5 */
+    Paf *s1 = stList_get(shards, 1);
+    CuAssertTrue(tc, s1->query_start  == 3);
+    CuAssertTrue(tc, s1->query_end    == 7);
+    CuAssertTrue(tc, s1->target_start == 5);
+    CuAssertTrue(tc, s1->target_end   == 9);
+
+    stList_destruct(shards);
+    paf_destruct(paf);
+}
+
+static void test_paf_shatter_opposite_strand(CuTest *tc) {
+    /* "3M2D4M": query span=7, target span=9; opposite strand.
+     * query_coordinate starts at query_end=7 and decrements.
+     * 3M: coord 7-3=4 → shard(4,0,3): qs=4,qe=7, ts=0,te=3; target_coord → 3
+     * 2D: target_coord → 5
+     * 4M: coord 4-4=0 → shard(0,5,4): qs=0,qe=4, ts=5,te=9 */
+    Paf *paf = make_paf("q", 100, 0, 7, false, "t", 100, 0, 9, 7, 9, 60, "3M2D4M");
+    stList *shards = paf_shatter(paf);
+    CuAssertIntEquals(tc, 2, stList_length(shards));
+
+    Paf *s0 = stList_get(shards, 0);
+    CuAssertTrue(tc, s0->query_start  == 4);
+    CuAssertTrue(tc, s0->query_end    == 7);
+    CuAssertTrue(tc, s0->target_start == 0);
+    CuAssertTrue(tc, s0->target_end   == 3);
+
+    Paf *s1 = stList_get(shards, 1);
+    CuAssertTrue(tc, s1->query_start  == 0);
+    CuAssertTrue(tc, s1->query_end    == 4);
+    CuAssertTrue(tc, s1->target_start == 5);
+    CuAssertTrue(tc, s1->target_end   == 9);
+
+    stList_destruct(shards);
+    paf_destruct(paf);
+}
+
+/* ---- 11. Mismatch encoding ---- */
+
+static void test_paf_encode_mismatches_all_match(CuTest *tc) {
+    Paf *paf = make_paf("q", 5, 0, 5, true, "t", 5, 0, 5, 5, 5, 60, "5M");
+    char query_seq[]  = "AAAAA";
+    char target_seq[] = "AAAAA";
+    paf_encode_mismatches(paf, query_seq, target_seq);
+    CuAssertIntEquals(tc, 1, cigar_count(paf->cigar));
+    CuAssertIntEquals(tc, sequence_match, cigar_get(paf->cigar, 0)->op);
+    CuAssertTrue(tc, cigar_get(paf->cigar, 0)->length == 5);
+    paf_destruct(paf);
+}
+
+static void test_paf_encode_mismatches_all_mismatch(CuTest *tc) {
+    Paf *paf = make_paf("q", 5, 0, 5, true, "t", 5, 0, 5, 0, 5, 60, "5M");
+    char query_seq[]  = "AAAAA";
+    char target_seq[] = "CCCCC";
+    paf_encode_mismatches(paf, query_seq, target_seq);
+    CuAssertIntEquals(tc, 1, cigar_count(paf->cigar));
+    CuAssertIntEquals(tc, sequence_mismatch, cigar_get(paf->cigar, 0)->op);
+    CuAssertTrue(tc, cigar_get(paf->cigar, 0)->length == 5);
+    paf_destruct(paf);
+}
+
+static void test_paf_encode_mismatches_mixed(CuTest *tc) {
+    /* target="AACC", query="AATT": AA match, CC vs TT mismatch → 2=2X */
+    Paf *paf = make_paf("q", 4, 0, 4, true, "t", 4, 0, 4, 2, 4, 60, "4M");
+    char query_seq[]  = "AATT";
+    char target_seq[] = "AACC";
+    paf_encode_mismatches(paf, query_seq, target_seq);
+    CuAssertIntEquals(tc, 2, cigar_count(paf->cigar));
+    CuAssertIntEquals(tc, sequence_match,    cigar_get(paf->cigar, 0)->op);
+    CuAssertTrue(tc, cigar_get(paf->cigar, 0)->length == 2);
+    CuAssertIntEquals(tc, sequence_mismatch, cigar_get(paf->cigar, 1)->op);
+    CuAssertTrue(tc, cigar_get(paf->cigar, 1)->length == 2);
+    paf_destruct(paf);
+}
+
+static void test_paf_remove_mismatches(CuTest *tc) {
+    /* "3=2X1I": = and X merge into 5M; I preserved → "5M1I"
+     * query span=3+2+1=6, target span=3+2=5 */
+    Paf *paf = make_paf("q", 100, 0, 6, true, "t", 100, 0, 5, 5, 6, 60, "3=2X1I");
+    paf_remove_mismatches(paf);
+    CuAssertIntEquals(tc, 2, cigar_count(paf->cigar));
+    CuAssertIntEquals(tc, match,        cigar_get(paf->cigar, 0)->op);
+    CuAssertTrue(tc, cigar_get(paf->cigar, 0)->length == 5);
+    CuAssertIntEquals(tc, query_insert, cigar_get(paf->cigar, 1)->op);
+    CuAssertTrue(tc, cigar_get(paf->cigar, 1)->length == 1);
+    paf_destruct(paf);
+}
+
+/* ---- 12. Coverage tracking ---- */
+
+static void test_coverage_tracking(CuTest *tc) {
+    stHash *h = stHash_construct3(stHash_stringKey, stHash_stringEqualKey,
+                                  NULL, (void(*)(void*))sequenceCountArray_destruct);
+
+    /* "3M" covering query positions 2,3,4 */
+    Paf *paf = make_paf("seq1", 10, 2, 5, true, "t", 100, 0, 3, 3, 3, 60, "3M");
+
+    /* First call creates the array */
+    SequenceCountArray *arr1 = get_alignment_count_array(h, paf);
+    CuAssertTrue(tc, arr1 != NULL);
+    CuAssertTrue(tc, arr1->length == 10);
+
+    /* Second call with same query name returns the same array */
+    SequenceCountArray *arr2 = get_alignment_count_array(h, paf);
+    CuAssertTrue(tc, arr1 == arr2);
+
+    /* Increment counts */
+    increase_alignment_level_counts(arr1, paf);
+    CuAssertTrue(tc, arr1->counts[0] == 0);
+    CuAssertTrue(tc, arr1->counts[1] == 0);
+    CuAssertTrue(tc, arr1->counts[2] == 1);
+    CuAssertTrue(tc, arr1->counts[3] == 1);
+    CuAssertTrue(tc, arr1->counts[4] == 1);
+    CuAssertTrue(tc, arr1->counts[5] == 0);
+
+    paf_destruct(paf);
+    stHash_destruct(h);
+}
+
+/* ---- 13. Interval functions ---- */
+
+static void test_decode_fasta_header(CuTest *tc) {
+    /* fasta_chunk format: "name|sequenceLength|chunkStart"
+     * decode pops last two fields as start then length */
+    Interval *iv = decode_fasta_header("seqname|100|0");
+    CuAssertStrEquals(tc, "seqname", iv->name);
+    CuAssertTrue(tc, iv->start  == 0);
+    CuAssertTrue(tc, iv->length == 100);
+    interval_destruct(iv);
+}
+
+static void test_cmp_intervals(CuTest *tc) {
+    Interval a = { .name = "chr1", .start = 10, .end = 100, .length = 90 };
+    Interval b = { .name = "chr1", .start = 20, .end = 200, .length = 180 };
+    Interval c = { .name = "chr2", .start = 5,  .end = 50,  .length = 45 };
+
+    /* same name: compare by start */
+    CuAssertTrue(tc, cmp_intervals(&a, &b) < 0);
+    CuAssertTrue(tc, cmp_intervals(&b, &a) > 0);
+    CuAssertTrue(tc, cmp_intervals(&a, &a) == 0);
+
+    /* different names: lexicographic */
+    CuAssertTrue(tc, cmp_intervals(&a, &c) < 0); /* "chr1" < "chr2" */
+    CuAssertTrue(tc, cmp_intervals(&c, &a) > 0);
+}
+
+/* ---- Registration ---- */
+
+CuSuite *addPafUnitTestSuite(void) {
+    CuSuite *suite = CuSuiteNew();
+    SUITE_ADD_TEST(suite, test_cigar_parse_empty);
+    SUITE_ADD_TEST(suite, test_cigar_parse_single);
+    SUITE_ADD_TEST(suite, test_cigar_parse_all_ops);
+    SUITE_ADD_TEST(suite, test_cigar_parse_large_length);
+    SUITE_ADD_TEST(suite, test_cigar_count_get);
+    SUITE_ADD_TEST(suite, test_paf_parse_minimal);
+    SUITE_ADD_TEST(suite, test_paf_parse_with_cigar);
+    SUITE_ADD_TEST(suite, test_paf_parse_cigar_string_mode);
+    SUITE_ADD_TEST(suite, test_paf_parse_optional_tags);
+    SUITE_ADD_TEST(suite, test_paf_parse_strand);
+    SUITE_ADD_TEST(suite, test_paf_roundtrip_no_cigar);
+    SUITE_ADD_TEST(suite, test_paf_roundtrip_with_cigar);
+    SUITE_ADD_TEST(suite, test_paf_read_write);
+    SUITE_ADD_TEST(suite, test_read_write_pafs_list);
+    SUITE_ADD_TEST(suite, test_paf_stats_calc_all_match);
+    SUITE_ADD_TEST(suite, test_paf_stats_calc_mixed);
+    SUITE_ADD_TEST(suite, test_paf_stats_calc_zero_flag);
+    SUITE_ADD_TEST(suite, test_paf_invert_same_strand);
+    SUITE_ADD_TEST(suite, test_paf_invert_opposite_strand);
+    SUITE_ADD_TEST(suite, test_paf_invert_double);
+    SUITE_ADD_TEST(suite, test_aligned_bases);
+    SUITE_ADD_TEST(suite, test_paf_trim_ends_zero);
+    SUITE_ADD_TEST(suite, test_paf_trim_ends_same_strand);
+    SUITE_ADD_TEST(suite, test_paf_trim_ends_with_gaps);
+    SUITE_ADD_TEST(suite, test_paf_trim_end_fraction);
+    SUITE_ADD_TEST(suite, test_paf_shatter_single_match);
+    SUITE_ADD_TEST(suite, test_paf_shatter_multi_match);
+    SUITE_ADD_TEST(suite, test_paf_shatter_opposite_strand);
+    SUITE_ADD_TEST(suite, test_paf_encode_mismatches_all_match);
+    SUITE_ADD_TEST(suite, test_paf_encode_mismatches_all_mismatch);
+    SUITE_ADD_TEST(suite, test_paf_encode_mismatches_mixed);
+    SUITE_ADD_TEST(suite, test_paf_remove_mismatches);
+    SUITE_ADD_TEST(suite, test_coverage_tracking);
+    SUITE_ADD_TEST(suite, test_decode_fasta_header);
+    SUITE_ADD_TEST(suite, test_cmp_intervals);
+    return suite;
+}

--- a/tests/paf_unit_test.c
+++ b/tests/paf_unit_test.c
@@ -629,6 +629,107 @@ static void test_cmp_intervals(CuTest *tc) {
     CuAssertTrue(tc, cmp_intervals(&c, &a) > 0);
 }
 
+/* ---- 14. paf_trim_unreliable_tails ---- */
+
+static void test_paf_trim_unreliable_tails_trims_tails(CuTest *tc) {
+    /* "2X5=2X": query span=9, target span=9, same_strand=false.
+     * matches=5, mismatches=4, identity=5/9; score_fraction=0 so threshold=identity.
+     * For same_strand=false the suffix is trimmed via invert+trim+invert:
+     * both 2X tails are removed, leaving "5=", query=(2,7), target=(2,7). */
+    Paf *paf = make_paf("q", 9, 0, 9, false, "t", 9, 0, 9, 5, 9, 60, "2X5=2X");
+    paf_trim_unreliable_tails(paf, 0.0f, 1.0f);
+    CuAssertTrue(tc, paf->query_start  == 2);
+    CuAssertTrue(tc, paf->query_end    == 7);
+    CuAssertTrue(tc, paf->target_start == 2);
+    CuAssertTrue(tc, paf->target_end   == 7);
+    CuAssertIntEquals(tc, 1, cigar_count(paf->cigar));
+    CuAssertIntEquals(tc, sequence_match, cigar_get(paf->cigar, 0)->op);
+    CuAssertTrue(tc, cigar_get(paf->cigar, 0)->length == 5);
+    paf_destruct(paf);
+}
+
+static void test_paf_trim_unreliable_tails_no_trim(CuTest *tc) {
+    /* score_fraction=1.0 → identity_threshold = identity - identity*1 = 0.
+     * No prefix can have identity < 0, so nothing is trimmed. */
+    Paf *paf = make_paf("q", 9, 0, 9, true, "t", 9, 0, 9, 5, 9, 60, "2X5=2X");
+    paf_trim_unreliable_tails(paf, 1.0f, 1.0f);
+    CuAssertTrue(tc, paf->query_start  == 0);
+    CuAssertTrue(tc, paf->query_end    == 9);
+    CuAssertTrue(tc, paf->target_start == 0);
+    CuAssertTrue(tc, paf->target_end   == 9);
+    CuAssertIntEquals(tc, 3, cigar_count(paf->cigar));
+    CuAssertIntEquals(tc, sequence_mismatch, cigar_get(paf->cigar, 0)->op);
+    CuAssertTrue(tc, cigar_get(paf->cigar, 0)->length == 2);
+    CuAssertIntEquals(tc, sequence_match, cigar_get(paf->cigar, 1)->op);
+    CuAssertTrue(tc, cigar_get(paf->cigar, 1)->length == 5);
+    CuAssertIntEquals(tc, sequence_mismatch, cigar_get(paf->cigar, 2)->op);
+    CuAssertTrue(tc, cigar_get(paf->cigar, 2)->length == 2);
+    paf_destruct(paf);
+}
+
+static void test_paf_trim_unreliable_tails_opposite_strand(CuTest *tc) {
+    /* same_strand=false: paf_trim_upto decrements query_end (not query_start)
+     * because the query is on the opposite strand.
+     * "2X5=": query span=7, target span=7, same_strand=false.
+     * identity=5/7; threshold=5/7 (score_fraction=0).
+     * After prefix trim: query_end decremented by 2 to 5; target_start incremented to 2.
+     * The suffix "5=" has identity 1.0 > threshold and is not trimmed. */
+    Paf *paf = make_paf("q", 9, 0, 7, false, "t", 9, 0, 7, 5, 7, 60, "2X5=");
+    paf_trim_unreliable_tails(paf, 0.0f, 1.0f);
+    CuAssertTrue(tc, paf->query_start  == 0);  /* not incremented for opp strand */
+    CuAssertTrue(tc, paf->query_end    == 5);  /* decremented by 2 */
+    CuAssertTrue(tc, paf->target_start == 2);  /* incremented */
+    CuAssertTrue(tc, paf->target_end   == 7);  /* unchanged */
+    CuAssertIntEquals(tc, 1, cigar_count(paf->cigar));
+    CuAssertIntEquals(tc, sequence_match, cigar_get(paf->cigar, 0)->op);
+    CuAssertTrue(tc, cigar_get(paf->cigar, 0)->length == 5);
+    paf_destruct(paf);
+}
+
+/* ---- 15. paf_pretty_print ---- */
+
+static void test_paf_pretty_print_basic(CuTest *tc) {
+    /* Call paf_pretty_print with include_alignment=false and verify that
+     * a non-empty header line is written to the output file. */
+    Paf *paf = make_paf("q", 10, 0, 5, true, "t", 10, 0, 5, 5, 5, 60, "5=");
+    FILE *fh = tmpfile();
+    CuAssertTrue(tc, fh != NULL);
+    paf_pretty_print(paf, NULL, NULL, fh, false);
+    CuAssertTrue(tc, ftell(fh) > 0);  /* output is non-empty */
+    fclose(fh);
+    paf_destruct(paf);
+}
+
+/* ---- 16. paf_check (positive path) ---- */
+
+static void test_paf_check_valid(CuTest *tc) {
+    /* paf_check should not abort on valid records; reaching the end of this
+     * function without st_errAbort is the success criterion. */
+    Paf *p;
+
+    /* same-strand, no cigar */
+    p = make_paf("q", 100, 0, 50, true, "t", 200, 10, 60, 50, 50, 60, NULL);
+    paf_check(p);
+    paf_destruct(p);
+
+    /* opposite-strand, no cigar */
+    p = make_paf("q", 100, 0, 50, false, "t", 200, 10, 60, 50, 50, 60, NULL);
+    paf_check(p);
+    paf_destruct(p);
+
+    /* same-strand with simple cigar */
+    p = make_paf("q", 100, 0, 5, true, "t", 100, 0, 5, 5, 5, 60, "5=");
+    paf_check(p);
+    paf_destruct(p);
+
+    /* cigar with indels: "3=2X1I2D", query span=3+2+1=6, target span=3+2+2=7 */
+    p = make_paf("q", 100, 0, 6, true, "t", 100, 0, 7, 5, 8, 60, "3=2X1I2D");
+    paf_check(p);
+    paf_destruct(p);
+
+    CuAssertTrue(tc, 1);  /* reached here without aborting */
+}
+
 /* ---- Registration ---- */
 
 CuSuite *addPafUnitTestSuite(void) {
@@ -668,5 +769,10 @@ CuSuite *addPafUnitTestSuite(void) {
     SUITE_ADD_TEST(suite, test_coverage_tracking);
     SUITE_ADD_TEST(suite, test_decode_fasta_header);
     SUITE_ADD_TEST(suite, test_cmp_intervals);
+    SUITE_ADD_TEST(suite, test_paf_trim_unreliable_tails_trims_tails);
+    SUITE_ADD_TEST(suite, test_paf_trim_unreliable_tails_no_trim);
+    SUITE_ADD_TEST(suite, test_paf_trim_unreliable_tails_opposite_strand);
+    SUITE_ADD_TEST(suite, test_paf_pretty_print_basic);
+    SUITE_ADD_TEST(suite, test_paf_check_valid);
     return suite;
 }


### PR DESCRIPTION
## Summary
- Adds a new `paffy split_file` command that splits a PAF file into separate output files by target (reference) contig name
- Supports `--minTargetLength` threshold to group small contigs into a single combined `<prefix>small.paf` file
- Streaming implementation using `stHash` of lazily-opened file handles; no CIGAR parsing needed
- Fills unit-test and integration-test coverage gaps for existing API functions and CLI options

## New tests
**Unit tests** (`tests/paf_unit_test.c`, 5 new cases):
- `paf_trim_unreliable_tails`: trims both tails (opposite-strand), no-trim path (score_fraction=1), and opposite-strand coordinate convention (query_end decremented, not query_start)
- `paf_pretty_print`: non-empty output produced with `include_alignment=false`
- `paf_check`: positive path — valid records accepted without aborting

**Integration tests** (`tests/paf_tools_test.sh`, 9 new cases):
- `paffy to_bed` basic, `-b` (binary), `-e` (exclude unaligned), `-f` (exclude aligned), `-n` (include inverted)
- `paffy filter -u` (min identity), `-v` (min identity with gaps), `-w` (max tile level)
- `paffy trim -f` (fixed trim)
- `paffy dedupe -a` (check inverse)

## Test plan
- [x] `make` compiles cleanly
- [x] All 40 unit tests pass (`bin/paffyTests`)
- [x] `tests/paf_tools_test.sh` passes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)